### PR TITLE
fix to paths coming from $(input-file) having an extra slash

### DIFF
--- a/libraries/datastore/data-store/data-store.ts
+++ b/libraries/datastore/data-store/data-store.ts
@@ -136,7 +136,7 @@ class ReadThroughDataSource extends DataSource {
           if (data) {
             const parent = ParentFolderUri(uri) || '';
             // hack to let $(this-folder) resolve to the location...
-            data = data.replace(/\$\(this-folder\)/g, parent);
+            data = data.replace(/\$\(this-folder\)\/*/g, parent);
           }
         } finally {
           if (!data) {


### PR DESCRIPTION
Example:
$(this-folder)directives.md
$(this-folder)/directives.md

Both things should resolve to the same thing.