### PR TITLE
Add x-ms-header-collection-prefix to whitelisted extensions

### DIFF
--- a/libraries/oai2-to-oai3/main.ts
+++ b/libraries/oai2-to-oai3/main.ts
@@ -223,7 +223,8 @@ export class Oai2ToOai3 {
         'x-ms-parameter-grouping',
         'x-ms-client-name',
         'x-ms-client-flatten',
-        'x-ms-client-request-id'
+        'x-ms-client-request-id',
+        'x-ms-header-collection-prefix'
       ]
 
       for (const key of parameterUnchangedProperties) {


### PR DESCRIPTION
This change adds `x-ms-header-collection-prefix` to the list of whitelisted extensions when converting OpenAPI 2 specs to OpenAPI 3.

/cc @fearthecowboy 