### PR TITLE
Add Schema fields to track usage contexts and media types

### DIFF
--- a/codemodel/.resources/all-in-one/json/code-model.json
+++ b/codemodel/.resources/all-in-one/json/code-model.json
@@ -1067,6 +1067,47 @@
         }
       ]
     },
+    "SchemaContext": {
+      "enum": [
+        "input",
+        "output"
+      ],
+      "type": "string"
+    },
+    "SchemaUsage": {
+      "type": "object",
+      "properties": {
+        "usage": {
+          "description": "contexts in which the schema is used",
+          "type": "array",
+          "items": {
+            "enum": [
+              "input",
+              "output"
+            ],
+            "type": "string"
+          }
+        },
+        "serializationFormats": {
+          "description": "Known media types in which this schema can be serialized",
+          "type": "array",
+          "items": {
+            "enum": [
+              "binary",
+              "form",
+              "json",
+              "multipart",
+              "text",
+              "unknown",
+              "xml"
+            ],
+            "type": "string"
+          }
+        }
+      },
+      "defaultProperties": [],
+      "additionalProperties": false
+    },
     "Relations": {
       "type": "object",
       "properties": {
@@ -1144,6 +1185,33 @@
           "items": {
             "$ref": "#/definitions/GroupProperty"
           }
+        },
+        "usage": {
+          "description": "contexts in which the schema is used",
+          "type": "array",
+          "items": {
+            "enum": [
+              "input",
+              "output"
+            ],
+            "type": "string"
+          }
+        },
+        "serializationFormats": {
+          "description": "Known media types in which this schema can be serialized",
+          "type": "array",
+          "items": {
+            "enum": [
+              "binary",
+              "form",
+              "json",
+              "multipart",
+              "text",
+              "unknown",
+              "xml"
+            ],
+            "type": "string"
+          }
         }
       },
       "defaultProperties": [],
@@ -1190,6 +1258,33 @@
         },
         "discriminatorValue": {
           "type": "string"
+        },
+        "usage": {
+          "description": "contexts in which the schema is used",
+          "type": "array",
+          "items": {
+            "enum": [
+              "input",
+              "output"
+            ],
+            "type": "string"
+          }
+        },
+        "serializationFormats": {
+          "description": "Known media types in which this schema can be serialized",
+          "type": "array",
+          "items": {
+            "enum": [
+              "binary",
+              "form",
+              "json",
+              "multipart",
+              "text",
+              "unknown",
+              "xml"
+            ],
+            "type": "string"
+          }
         }
       },
       "defaultProperties": [],
@@ -1719,7 +1814,7 @@
           }
         },
         "choices": {
-          "description": "- this is essentially can be thought of as an 'enum' \nthat is a choice between one of several items, but an unspecified value is permitted.",
+          "description": "- this is essentially can be thought of as an 'enum'\nthat is a choice between one of several items, but an unspecified value is permitted.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/ChoiceSchema"
@@ -1777,7 +1872,7 @@
           }
         },
         "unknowns": {
-          "description": "it's possible that we just may make this an error \nin representation.",
+          "description": "it's possible that we just may make this an error\nin representation.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/Schema"

--- a/codemodel/.resources/all-in-one/yaml/code-model.yaml
+++ b/codemodel/.resources/all-in-one/yaml/code-model.yaml
@@ -663,6 +663,27 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/GroupProperty'
+      serializationFormats:
+        type: array
+        description: Known media types in which this schema can be serialized
+        items:
+          type: string
+          enum:
+            - binary
+            - form
+            - json
+            - multipart
+            - text
+            - unknown
+            - xml
+      usage:
+        type: array
+        description: contexts in which the schema is used
+        items:
+          type: string
+          enum:
+            - input
+            - output
     required:
       - language
       - protocol
@@ -1247,6 +1268,27 @@ definitions:
         description: the collection of properties that are in this object
         items:
           $ref: '#/definitions/Property'
+      serializationFormats:
+        type: array
+        description: Known media types in which this schema can be serialized
+        items:
+          type: string
+          enum:
+            - binary
+            - form
+            - json
+            - multipart
+            - text
+            - unknown
+            - xml
+      usage:
+        type: array
+        description: contexts in which the schema is used
+        items:
+          type: string
+          enum:
+            - input
+            - output
     required:
       - language
       - protocol
@@ -1590,6 +1632,11 @@ definitions:
       - language
       - protocol
       - type
+  SchemaContext:
+    type: string
+    enum:
+      - input
+      - output
   SchemaResponse:
     type: object
     description: a response that should be deserialized into a result of type(schema)
@@ -1638,6 +1685,31 @@ definitions:
       - uri
       - uuid
       - xor
+  SchemaUsage:
+    type: object
+    additionalProperties: false
+    properties:
+      serializationFormats:
+        type: array
+        description: Known media types in which this schema can be serialized
+        items:
+          type: string
+          enum:
+            - binary
+            - form
+            - json
+            - multipart
+            - text
+            - unknown
+            - xml
+      usage:
+        type: array
+        description: contexts in which the schema is used
+        items:
+          type: string
+          enum:
+            - input
+            - output
   Schemas:
     type: object
     description: 'the full set of schemas for a given service, categorized into convenient collections'
@@ -1670,7 +1742,7 @@ definitions:
       choices:
         type: array
         description: |-
-          - this is essentially can be thought of as an 'enum' 
+          - this is essentially can be thought of as an 'enum'
           that is a choice between one of several items, but an unspecified value is permitted.
         items:
           $ref: '#/definitions/ChoiceSchema'
@@ -1764,7 +1836,7 @@ definitions:
       unknowns:
         type: array
         description: |-
-          it's possible that we just may make this an error 
+          it's possible that we just may make this an error
           in representation.
         items:
           $ref: '#/definitions/Schema'

--- a/codemodel/.resources/model/json/enums.json
+++ b/codemodel/.resources/model/json/enums.json
@@ -45,6 +45,13 @@
       ],
       "type": "string"
     },
+    "SchemaContext": {
+      "enum": [
+        "input",
+        "output"
+      ],
+      "type": "string"
+    },
     "SerializationStyle": {
       "description": "The Serialization Style used for the parameter.\n\nDescribes how the parameter value will be serialized depending on the type of the parameter value.",
       "enum": [

--- a/codemodel/.resources/model/json/master.json
+++ b/codemodel/.resources/model/json/master.json
@@ -448,6 +448,40 @@
         }
       ]
     },
+    "SchemaUsage": {
+      "type": "object",
+      "properties": {
+        "usage": {
+          "description": "contexts in which the schema is used",
+          "type": "array",
+          "items": {
+            "enum": [
+              "input",
+              "output"
+            ],
+            "type": "string"
+          }
+        },
+        "serializationFormats": {
+          "description": "Known media types in which this schema can be serialized",
+          "type": "array",
+          "items": {
+            "enum": [
+              "binary",
+              "form",
+              "json",
+              "multipart",
+              "text",
+              "unknown",
+              "xml"
+            ],
+            "type": "string"
+          }
+        }
+      },
+      "defaultProperties": [],
+      "additionalProperties": false
+    },
     "Relations": {
       "type": "object",
       "properties": {

--- a/codemodel/.resources/model/json/schemas.json
+++ b/codemodel/.resources/model/json/schemas.json
@@ -403,6 +403,33 @@
           "items": {
             "$ref": "./master.json#/definitions/GroupProperty"
           }
+        },
+        "usage": {
+          "description": "contexts in which the schema is used",
+          "type": "array",
+          "items": {
+            "enum": [
+              "input",
+              "output"
+            ],
+            "type": "string"
+          }
+        },
+        "serializationFormats": {
+          "description": "Known media types in which this schema can be serialized",
+          "type": "array",
+          "items": {
+            "enum": [
+              "binary",
+              "form",
+              "json",
+              "multipart",
+              "text",
+              "unknown",
+              "xml"
+            ],
+            "type": "string"
+          }
         }
       },
       "defaultProperties": [],
@@ -449,6 +476,33 @@
         },
         "discriminatorValue": {
           "type": "string"
+        },
+        "usage": {
+          "description": "contexts in which the schema is used",
+          "type": "array",
+          "items": {
+            "enum": [
+              "input",
+              "output"
+            ],
+            "type": "string"
+          }
+        },
+        "serializationFormats": {
+          "description": "Known media types in which this schema can be serialized",
+          "type": "array",
+          "items": {
+            "enum": [
+              "binary",
+              "form",
+              "json",
+              "multipart",
+              "text",
+              "unknown",
+              "xml"
+            ],
+            "type": "string"
+          }
         }
       },
       "defaultProperties": [],
@@ -897,7 +951,7 @@
           }
         },
         "choices": {
-          "description": "- this is essentially can be thought of as an 'enum' \nthat is a choice between one of several items, but an unspecified value is permitted.",
+          "description": "- this is essentially can be thought of as an 'enum'\nthat is a choice between one of several items, but an unspecified value is permitted.",
           "type": "array",
           "items": {
             "$ref": "./schemas.json#/definitions/ChoiceSchema"
@@ -955,7 +1009,7 @@
           }
         },
         "unknowns": {
-          "description": "it's possible that we just may make this an error \nin representation.",
+          "description": "it's possible that we just may make this an error\nin representation.",
           "type": "array",
           "items": {
             "$ref": "./schemas.json#/definitions/Schema"

--- a/codemodel/.resources/model/yaml/enums.yaml
+++ b/codemodel/.resources/model/yaml/enums.yaml
@@ -58,6 +58,11 @@ definitions:
       - form
       - pipeDelimited
       - spaceDelimited
+  SchemaContext:
+    type: string
+    enum:
+      - input
+      - output
   SchemaType:
     type: string
     description: possible schema types that indicate the type of schema.

--- a/codemodel/.resources/model/yaml/master.yaml
+++ b/codemodel/.resources/model/yaml/master.yaml
@@ -520,6 +520,31 @@ definitions:
       - language
       - protocol
       - schema
+  SchemaUsage:
+    type: object
+    additionalProperties: false
+    properties:
+      serializationFormats:
+        type: array
+        description: Known media types in which this schema can be serialized
+        items:
+          type: string
+          enum:
+            - binary
+            - form
+            - json
+            - multipart
+            - text
+            - unknown
+            - xml
+      usage:
+        type: array
+        description: contexts in which the schema is used
+        items:
+          type: string
+          enum:
+            - input
+            - output
   SerializationFormat:
     type: object
     additionalProperties: false

--- a/codemodel/.resources/model/yaml/schemas.yaml
+++ b/codemodel/.resources/model/yaml/schemas.yaml
@@ -309,6 +309,27 @@ definitions:
         type: array
         items:
           $ref: './master.yaml#/definitions/GroupProperty'
+      serializationFormats:
+        type: array
+        description: Known media types in which this schema can be serialized
+        items:
+          type: string
+          enum:
+            - binary
+            - form
+            - json
+            - multipart
+            - text
+            - unknown
+            - xml
+      usage:
+        type: array
+        description: contexts in which the schema is used
+        items:
+          type: string
+          enum:
+            - input
+            - output
     required:
       - language
       - protocol
@@ -395,6 +416,27 @@ definitions:
         description: the collection of properties that are in this object
         items:
           $ref: './master.yaml#/definitions/Property'
+      serializationFormats:
+        type: array
+        description: Known media types in which this schema can be serialized
+        items:
+          type: string
+          enum:
+            - binary
+            - form
+            - json
+            - multipart
+            - text
+            - unknown
+            - xml
+      usage:
+        type: array
+        description: contexts in which the schema is used
+        items:
+          type: string
+          enum:
+            - input
+            - output
     required:
       - language
       - protocol
@@ -499,7 +541,7 @@ definitions:
       choices:
         type: array
         description: |-
-          - this is essentially can be thought of as an 'enum' 
+          - this is essentially can be thought of as an 'enum'
           that is a choice between one of several items, but an unspecified value is permitted.
         items:
           $ref: './schemas.yaml#/definitions/ChoiceSchema'
@@ -593,7 +635,7 @@ definitions:
       unknowns:
         type: array
         description: |-
-          it's possible that we just may make this an error 
+          it's possible that we just may make this an error
           in representation.
         items:
           $ref: './schemas.yaml#/definitions/Schema'

--- a/codemodel/model/common/schema.ts
+++ b/codemodel/model/common/schema.ts
@@ -10,13 +10,6 @@ export interface SerializationFormat extends Extensions, Dictionary<any> {
 
 }
 
-export enum SchemaContext {
-  /** Schema is used as an input to an operation. */
-  Input = 'input',
-
-  /** Schema is used as an output from an operation. */
-  Output = 'output'
-}
 
 /** The Schema Object allows the definition of input and output data types. */
 export interface Schema extends Aspect {
@@ -37,12 +30,6 @@ export interface Schema extends Aspect {
 
   /** per-serialization information for this Schema  */
   serialization?: SerializationFormats;
-
-  /** contexts in which the schema is used */
-  contexts?: SchemaContext[];
-
-  /** Known media types in which this schema can be serialized */
-  knownMediaTypes?: string[];
 
   /* are these needed I don't think so? */
   // nullable: boolean;

--- a/codemodel/model/common/schema.ts
+++ b/codemodel/model/common/schema.ts
@@ -10,6 +10,14 @@ export interface SerializationFormat extends Extensions, Dictionary<any> {
 
 }
 
+export enum SchemaContext {
+  /** Schema is used as an input to an operation. */
+  Input = 'input',
+
+  /** Schema is used as an output from an operation. */
+  Output = 'output'
+}
+
 /** The Schema Object allows the definition of input and output data types. */
 export interface Schema extends Aspect {
   /** per-language information for Schema */
@@ -29,6 +37,12 @@ export interface Schema extends Aspect {
 
   /** per-serialization information for this Schema  */
   serialization?: SerializationFormats;
+
+  /** contexts in which the schema is used */
+  contexts?: SchemaContext[];
+
+  /** Known media types in which this schema can be serialized */
+  knownMediaTypes?: string[];
 
   /* are these needed I don't think so? */
   // nullable: boolean;

--- a/codemodel/model/common/schemas.ts
+++ b/codemodel/model/common/schemas.ts
@@ -17,6 +17,8 @@ import { BinarySchema } from './schemas/binary';
 import { finished } from 'stream';
 import { AnySchema } from './schemas/any';
 
+export { SchemaUsage, SchemaContext } from './schemas/usage';
+
 /** the full set of schemas for a given service, categorized into convenient collections */
 export interface Schemas {
   /** a collection of items */

--- a/codemodel/model/common/schemas/object.ts
+++ b/codemodel/model/common/schemas/object.ts
@@ -4,6 +4,7 @@ import { DeepPartial } from '@azure-tools/codegen';
 import { Property } from '../property';
 import { Dictionary, values } from '@azure-tools/linq';
 import { Parameter } from '../parameter';
+import { SchemaUsage } from './usage';
 
 export interface Relations {
   immediate: Array<ComplexSchema>;
@@ -42,7 +43,7 @@ export class GroupProperty extends Property implements GroupProperty {
   }
 }
 
-export interface GroupSchema extends Schema {
+export interface GroupSchema extends Schema, SchemaUsage {
   type: SchemaType.Group;
   properties?: Array<GroupProperty>;
 }
@@ -59,7 +60,7 @@ export class GroupSchema extends Schema implements GroupSchema {
 }
 
 /** a schema that represents a type with child properties. */
-export interface ObjectSchema extends ComplexSchema {
+export interface ObjectSchema extends ComplexSchema, SchemaUsage {
   /** the schema type  */
   type: SchemaType.Object;
 

--- a/codemodel/model/common/schemas/usage.ts
+++ b/codemodel/model/common/schemas/usage.ts
@@ -1,0 +1,17 @@
+import { KnownMediaType } from "@azure-tools/codegen";
+
+export enum SchemaContext {
+  /** Schema is used as an input to an operation. */
+  Input = "input",
+
+  /** Schema is used as an output from an operation. */
+  Output = "output"
+}
+
+export interface SchemaUsage {
+  /** contexts in which the schema is used */
+  usage?: SchemaContext[];
+
+  /** Known media types in which this schema can be serialized */
+  serializationFormats?: KnownMediaType[];
+}

--- a/codemodel/package.json
+++ b/codemodel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/codemodel",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "patchOffset": 100,
   "description": "AutoRest code model library",
   "directories": {


### PR DESCRIPTION
This change is the first half of the fix for Azure/autorest.modelerfour#23.  It adds two new fields to the `Schema` type in `@azure-tools/codemodel` for tracking the `contexts` and `knownMediaTypes` where the schema is used.  This information is meant to be used by language extensions to determine how to generate the code to serialize a particular schema.

One change I'm considering to this approach is to move these two properties to a `usage` field on `Schema` so that they don't pollute the top level properties of that type.  Thoughts on that?

I am certainly interested in feedback from @MiYanni and @pakrym about whether this is what you had in mind.