### PR TITLE
Fix issues with code model tagging and schema generation

### DIFF
--- a/codemodel/.resources/all-in-one/json/code-model.json
+++ b/codemodel/.resources/all-in-one/json/code-model.json
@@ -1081,27 +1081,14 @@
           "description": "contexts in which the schema is used",
           "type": "array",
           "items": {
-            "enum": [
-              "input",
-              "output"
-            ],
-            "type": "string"
+            "$ref": "#/definitions/SchemaContext"
           }
         },
         "serializationFormats": {
           "description": "Known media types in which this schema can be serialized",
           "type": "array",
           "items": {
-            "enum": [
-              "binary",
-              "form",
-              "json",
-              "multipart",
-              "text",
-              "unknown",
-              "xml"
-            ],
-            "type": "string"
+            "$ref": "#/definitions/KnownMediaType"
           }
         }
       },
@@ -1185,33 +1172,6 @@
           "items": {
             "$ref": "#/definitions/GroupProperty"
           }
-        },
-        "usage": {
-          "description": "contexts in which the schema is used",
-          "type": "array",
-          "items": {
-            "enum": [
-              "input",
-              "output"
-            ],
-            "type": "string"
-          }
-        },
-        "serializationFormats": {
-          "description": "Known media types in which this schema can be serialized",
-          "type": "array",
-          "items": {
-            "enum": [
-              "binary",
-              "form",
-              "json",
-              "multipart",
-              "text",
-              "unknown",
-              "xml"
-            ],
-            "type": "string"
-          }
         }
       },
       "defaultProperties": [],
@@ -1224,6 +1184,9 @@
       "allOf": [
         {
           "$ref": "#/definitions/Schema"
+        },
+        {
+          "$ref": "#/definitions/SchemaUsage"
         }
       ]
     },
@@ -1258,33 +1221,6 @@
         },
         "discriminatorValue": {
           "type": "string"
-        },
-        "usage": {
-          "description": "contexts in which the schema is used",
-          "type": "array",
-          "items": {
-            "enum": [
-              "input",
-              "output"
-            ],
-            "type": "string"
-          }
-        },
-        "serializationFormats": {
-          "description": "Known media types in which this schema can be serialized",
-          "type": "array",
-          "items": {
-            "enum": [
-              "binary",
-              "form",
-              "json",
-              "multipart",
-              "text",
-              "unknown",
-              "xml"
-            ],
-            "type": "string"
-          }
         }
       },
       "defaultProperties": [],
@@ -1297,6 +1233,9 @@
       "allOf": [
         {
           "$ref": "#/definitions/ComplexSchema"
+        },
+        {
+          "$ref": "#/definitions/SchemaUsage"
         }
       ]
     },

--- a/codemodel/.resources/all-in-one/yaml/code-model.yaml
+++ b/codemodel/.resources/all-in-one/yaml/code-model.yaml
@@ -658,32 +658,12 @@ definitions:
     additionalProperties: false
     allOf:
       - $ref: '#/definitions/Schema'
+      - $ref: '#/definitions/SchemaUsage'
     properties:
       properties:
         type: array
         items:
           $ref: '#/definitions/GroupProperty'
-      serializationFormats:
-        type: array
-        description: Known media types in which this schema can be serialized
-        items:
-          type: string
-          enum:
-            - binary
-            - form
-            - json
-            - multipart
-            - text
-            - unknown
-            - xml
-      usage:
-        type: array
-        description: contexts in which the schema is used
-        items:
-          type: string
-          enum:
-            - input
-            - output
     required:
       - language
       - protocol
@@ -1247,6 +1227,7 @@ definitions:
     additionalProperties: false
     allOf:
       - $ref: '#/definitions/ComplexSchema'
+      - $ref: '#/definitions/SchemaUsage'
     properties:
       children:
         $ref: '#/definitions/Relations'
@@ -1268,27 +1249,6 @@ definitions:
         description: the collection of properties that are in this object
         items:
           $ref: '#/definitions/Property'
-      serializationFormats:
-        type: array
-        description: Known media types in which this schema can be serialized
-        items:
-          type: string
-          enum:
-            - binary
-            - form
-            - json
-            - multipart
-            - text
-            - unknown
-            - xml
-      usage:
-        type: array
-        description: contexts in which the schema is used
-        items:
-          type: string
-          enum:
-            - input
-            - output
     required:
       - language
       - protocol
@@ -1693,23 +1653,12 @@ definitions:
         type: array
         description: Known media types in which this schema can be serialized
         items:
-          type: string
-          enum:
-            - binary
-            - form
-            - json
-            - multipart
-            - text
-            - unknown
-            - xml
+          $ref: '#/definitions/KnownMediaType'
       usage:
         type: array
         description: contexts in which the schema is used
         items:
-          type: string
-          enum:
-            - input
-            - output
+          $ref: '#/definitions/SchemaContext'
   Schemas:
     type: object
     description: 'the full set of schemas for a given service, categorized into convenient collections'

--- a/codemodel/.resources/model/json/master.json
+++ b/codemodel/.resources/model/json/master.json
@@ -455,27 +455,14 @@
           "description": "contexts in which the schema is used",
           "type": "array",
           "items": {
-            "enum": [
-              "input",
-              "output"
-            ],
-            "type": "string"
+            "$ref": "./schemas.json#/definitions/SchemaContext"
           }
         },
         "serializationFormats": {
           "description": "Known media types in which this schema can be serialized",
           "type": "array",
           "items": {
-            "enum": [
-              "binary",
-              "form",
-              "json",
-              "multipart",
-              "text",
-              "unknown",
-              "xml"
-            ],
-            "type": "string"
+            "$ref": "./enums.json#/definitions/KnownMediaType"
           }
         }
       },

--- a/codemodel/.resources/model/json/schemas.json
+++ b/codemodel/.resources/model/json/schemas.json
@@ -403,33 +403,6 @@
           "items": {
             "$ref": "./master.json#/definitions/GroupProperty"
           }
-        },
-        "usage": {
-          "description": "contexts in which the schema is used",
-          "type": "array",
-          "items": {
-            "enum": [
-              "input",
-              "output"
-            ],
-            "type": "string"
-          }
-        },
-        "serializationFormats": {
-          "description": "Known media types in which this schema can be serialized",
-          "type": "array",
-          "items": {
-            "enum": [
-              "binary",
-              "form",
-              "json",
-              "multipart",
-              "text",
-              "unknown",
-              "xml"
-            ],
-            "type": "string"
-          }
         }
       },
       "defaultProperties": [],
@@ -442,6 +415,9 @@
       "allOf": [
         {
           "$ref": "./schemas.json#/definitions/Schema"
+        },
+        {
+          "$ref": "./schemas.json#/definitions/SchemaUsage"
         }
       ]
     },
@@ -476,33 +452,6 @@
         },
         "discriminatorValue": {
           "type": "string"
-        },
-        "usage": {
-          "description": "contexts in which the schema is used",
-          "type": "array",
-          "items": {
-            "enum": [
-              "input",
-              "output"
-            ],
-            "type": "string"
-          }
-        },
-        "serializationFormats": {
-          "description": "Known media types in which this schema can be serialized",
-          "type": "array",
-          "items": {
-            "enum": [
-              "binary",
-              "form",
-              "json",
-              "multipart",
-              "text",
-              "unknown",
-              "xml"
-            ],
-            "type": "string"
-          }
         }
       },
       "defaultProperties": [],
@@ -515,6 +464,9 @@
       "allOf": [
         {
           "$ref": "./schemas.json#/definitions/ComplexSchema"
+        },
+        {
+          "$ref": "./schemas.json#/definitions/SchemaUsage"
         }
       ]
     },

--- a/codemodel/.resources/model/yaml/master.yaml
+++ b/codemodel/.resources/model/yaml/master.yaml
@@ -528,23 +528,12 @@ definitions:
         type: array
         description: Known media types in which this schema can be serialized
         items:
-          type: string
-          enum:
-            - binary
-            - form
-            - json
-            - multipart
-            - text
-            - unknown
-            - xml
+          $ref: './enums.yaml#/definitions/KnownMediaType'
       usage:
         type: array
         description: contexts in which the schema is used
         items:
-          type: string
-          enum:
-            - input
-            - output
+          $ref: './schemas.yaml#/definitions/SchemaContext'
   SerializationFormat:
     type: object
     additionalProperties: false

--- a/codemodel/.resources/model/yaml/schemas.yaml
+++ b/codemodel/.resources/model/yaml/schemas.yaml
@@ -304,32 +304,12 @@ definitions:
     additionalProperties: false
     allOf:
       - $ref: './schemas.yaml#/definitions/Schema'
+      - $ref: './schemas.yaml#/definitions/SchemaUsage'
     properties:
       properties:
         type: array
         items:
           $ref: './master.yaml#/definitions/GroupProperty'
-      serializationFormats:
-        type: array
-        description: Known media types in which this schema can be serialized
-        items:
-          type: string
-          enum:
-            - binary
-            - form
-            - json
-            - multipart
-            - text
-            - unknown
-            - xml
-      usage:
-        type: array
-        description: contexts in which the schema is used
-        items:
-          type: string
-          enum:
-            - input
-            - output
     required:
       - language
       - protocol
@@ -395,6 +375,7 @@ definitions:
     additionalProperties: false
     allOf:
       - $ref: './schemas.yaml#/definitions/ComplexSchema'
+      - $ref: './schemas.yaml#/definitions/SchemaUsage'
     properties:
       children:
         $ref: './master.yaml#/definitions/Relations'
@@ -416,27 +397,6 @@ definitions:
         description: the collection of properties that are in this object
         items:
           $ref: './master.yaml#/definitions/Property'
-      serializationFormats:
-        type: array
-        description: Known media types in which this schema can be serialized
-        items:
-          type: string
-          enum:
-            - binary
-            - form
-            - json
-            - multipart
-            - text
-            - unknown
-            - xml
-      usage:
-        type: array
-        description: contexts in which the schema is used
-        items:
-          type: string
-          enum:
-            - input
-            - output
     required:
       - language
       - protocol

--- a/codemodel/.scripts/generate-schema.js
+++ b/codemodel/.scripts/generate-schema.js
@@ -7,7 +7,7 @@ const TJS = require("typescript-json-schema");
 const tsm = require('ts-morph');
 
 const project = new tsm.Project({ tsConfigFilePath: `{__dirname}/../tsconfig.json` });
-project.compilerOptions.set({ downlevelIteration: true });
+
 const x = project.getSourceFiles().map(each => each.getInterfaces());
 
 function flatten(arr) {
@@ -178,7 +178,6 @@ async function main() {
   schema.definitions['ConditionalSchema'].properties['conditionalType'].$ref = '#/definitions/PrimitiveSchema'
   schema.definitions['SealedConditionalSchema'].properties['conditionalType'].$ref = '#/definitions/PrimitiveSchema'
 
-
   for (let each in schema.definitions['CodeModel']) {
     schema[each] = schema.definitions['CodeModel'][each]
   }
@@ -226,6 +225,12 @@ async function main() {
   schema.definitions['SerializationFormats'].additionalProperties = false; // { type: 'object' };
 
   // console.log(schema.definitions['Language']);
+
+  // Fix up the SchemaUsage spec and its consumers
+  schema.definitions['SchemaUsage'].properties['usage'].items = { $ref: '#/definitions/SchemaContext' };
+  schema.definitions['SchemaUsage'].properties['serializationFormats'].items = { $ref: '#/definitions/KnownMediaType' };
+  refSchemaUsage(schema, 'ObjectSchema');
+  refSchemaUsage(schema, 'GroupSchema');
 
   // write out the full all in one model
   await writemodels('code-model', 'all-in-one', schema);
@@ -319,6 +324,12 @@ async function main() {
   for (const each in all) {
     await writemodels(each, 'model', all[each]);
   }
+}
+
+function refSchemaUsage(schema, schemaName) {
+  delete schema.definitions[schemaName].properties['usage'];
+  delete schema.definitions[schemaName].properties['serializationFormats'];
+  schema.definitions[schemaName].allOf.push({ $ref: `#/definitions/SchemaUsage` });
 }
 
 function moveTo(all, name, target, ) {

--- a/codemodel/.scripts/generate-schema.js
+++ b/codemodel/.scripts/generate-schema.js
@@ -146,7 +146,7 @@ async function main() {
     noExtraProps: true,
   };
 
-  const program = TJS.getProgramFromFiles(g.sync(`${__dirname}/../model/**/*.ts`), {}, __dirname);
+  const program = TJS.getProgramFromFiles(g.sync(`${__dirname}/../model/**/*.ts`), { downlevelIteration: true }, __dirname);
 
   // We can either get the schema for one file and one type...
   let schema = TJS.generateSchema(program, "*", settings);

--- a/codemodel/model/yaml-schema.ts
+++ b/codemodel/model/yaml-schema.ts
@@ -43,9 +43,9 @@ export const codeModelSchema = Schema.create(DEFAULT_SAFE_SCHEMA, [
   TypeInfo(HttpModel),
   TypeInfo(HttpParameter),
 
-  TypeInfo(HttpWithBodyRequest),
   TypeInfo(HttpBinaryRequest),
   TypeInfo(HttpMultipartRequest),
+  TypeInfo(HttpWithBodyRequest),
   TypeInfo(HttpRequest),
 
   TypeInfo(HttpBinaryResponse),

--- a/codemodel/package.json
+++ b/codemodel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/codemodel",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "patchOffset": 100,
   "description": "AutoRest code model library",
   "directories": {


### PR DESCRIPTION
This change fixes a couple of code model issues:

- https://github.com/Azure/autorest.modelerfour/issues/196: The `SchemaUsage` schema was not being ref'ed properly by `ObjectSchema` and `GroupSchema` in the generated code model schema and the `SchemaContext` and `KnownMediaType` schemas were not ref'ed in its properties.  The fix is to massage the generated schema a bit to make sure everything is ref'ed appropriately.

- https://github.com/Azure/autorest.modelerfour/issues/197: The `HttpBinaryRequest` type was not getting tagged correctly in code model YAML output.  The fix was to make sure that type is prioritized over its parent type `HttpWithBodyRequest` when picking type tags.

I've also fixed an issue that's been plaguing the `generate-schema.js` script where some TypeScript compiler errors were being thrown regarding generator functions in `codemodel/model/common/schemas/object.ts`.  The fix was to add the `downlevelIteration: true` compiler option when running `typescript-json-schema` because it apparently does its own compilation run.