### PR TITLE
Fix ordering of a couple more inherited YAML schema types

### DIFF
--- a/codemodel/model/yaml-schema.ts
+++ b/codemodel/model/yaml-schema.ts
@@ -58,10 +58,10 @@ export const codeModelSchema = Schema.create(DEFAULT_SAFE_SCHEMA, [
   TypeInfo(BinaryResponse),
   TypeInfo(Response),
 
-  TypeInfo(Parameter),
   TypeInfo(VirtualParameter),
-  TypeInfo(Property),
+  TypeInfo(Parameter),
   TypeInfo(GroupProperty),
+  TypeInfo(Property),
   TypeInfo(Value),
   TypeInfo(Operation),
   TypeInfo(GroupSchema),


### PR DESCRIPTION
@miyanni noticed a couple more schema types that were not ordered correctly for YAML schema output, causing the outputted schema to tag them incorrectly.  Just fixing the ordering of those types.