### PR TITLE
Add SerializeOptions for passing extra options to serialize<T>()

### DIFF
--- a/codegen/package.json
+++ b/codegen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/codegen",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "patchOffset": 100,
   "description": "Autorest Code generator common and base classes",
   "directories": {

--- a/codegen/yaml.ts
+++ b/codegen/yaml.ts
@@ -93,14 +93,23 @@ export function deserialize<T>(text: string, filename: string, schema: Schema = 
   });
 }
 
-export function serialize<T>(model: T, schema: Schema = DEFAULT_SAFE_SCHEMA): string {
+export interface SerializeOptions {
+  schema?: Schema,
+  sortKeys?: boolean
+}
+
+export function serialize<T>(model: T, schemaOrOptions: Schema | SerializeOptions = DEFAULT_SAFE_SCHEMA): string {
+  const options: SerializeOptions =
+    schemaOrOptions instanceof Schema
+      ? { schema: schemaOrOptions, sortKeys: true }
+      : { schema: DEFAULT_SAFE_SCHEMA, sortKeys: true, ... schemaOrOptions };
+
   return dump(model, {
-    schema: schema,
-    sortKeys: sortWithPriorty,
+    schema: options.schema,
+    sortKeys: options.sortKeys && sortWithPriorty,
     skipInvalid: true,
     noArrayIndent: true,
     lineWidth: 240,
-
   });
   // .replace(/\s*\w*: {}/g, '')
   // .replace(/\s*\w*: \[\]/g, '')


### PR DESCRIPTION
This change adds a new `SerializeOptions` interface that can be passed in as the second parameter to `serialize<T>()` so that YAML serialization can be further customized.  This is needed in `modelerfour` because the new `prechecker` phase needs to serialize a sanitized version of the OpenAPI 3 document without sorting the object fields.