### PR TITLE
Pass along parameters to normalize when called recursively

### DIFF
--- a/codegen/formatter.ts
+++ b/codegen/formatter.ts
@@ -59,7 +59,9 @@ function normalize(identifier: string | Array<string>, removeDuplicates = true, 
   if (!identifier || identifier.length === 0) {
     return [''];
   }
-  return typeof identifier === 'string' ? normalize(fixLeadingNumber(deconstruct(identifier, maxUppercasePreserve))) : removeDuplicates ? removeSequentialDuplicates(identifier) : identifier;
+  return typeof identifier === 'string'
+    ? normalize(fixLeadingNumber(deconstruct(identifier, maxUppercasePreserve)), removeDuplicates, overrides, maxUppercasePreserve)
+    : removeDuplicates ? removeSequentialDuplicates(identifier) : identifier;
 }
 export class Style {
   static select(style: any, fallback: Styler, maxUppercasePreserve: number): Styler {


### PR DESCRIPTION
While testing Azure/autorest.modelerfour#279 I realized that the `removeDuplicates` parameter to `normalize` wasn't being respected properly.  Turns out that there's a recursive call inside of `normalize` when the first parameter is a `string` and the remaining parameters are not being passed along to the recursive call.  After this change the fix in the modelerfour PR works correctly.

I'm assuming I don't need to do a minor version bump since this doesn't affect public API surface, is that correct?