### PR TITLE
Indent arrays when serializing YAML to avoid deserializtion issues

### DIFF
--- a/codegen/yaml.ts
+++ b/codegen/yaml.ts
@@ -108,7 +108,6 @@ export function serialize<T>(model: T, schemaOrOptions: Schema | SerializeOption
     schema: options.schema,
     sortKeys: options.sortKeys && sortWithPriorty,
     skipInvalid: true,
-    noArrayIndent: true,
     lineWidth: 240,
   });
   // .replace(/\s*\w*: {}/g, '')


### PR DESCRIPTION
This change attempts to address https://github.com/Azure/autorest.modelerfour/issues/270 which reports that some service specs throw fatal YAML deserialization errors after an earlier pipeline plugin has serialized out the current data to YAML.  It turns out that this might be caused by the `noArrayIndent: true` setting plus the structure of the output after processing these documents.  This PR aims to try removing this option to see if it alleviates the problem.