### PR TITLE
Add `nullableItems` to ArraySchema and DictionarySchema

### DIFF
--- a/codemodel/.resources/all-in-one/json/code-model.json
+++ b/codemodel/.resources/all-in-one/json/code-model.json
@@ -759,6 +759,10 @@
         "uniqueItems": {
           "description": "if the elements in the array should be unique",
           "type": "boolean"
+        },
+        "nullableItems": {
+          "description": "if elements in the array should be nullable",
+          "type": "boolean"
         }
       },
       "defaultProperties": [],
@@ -809,6 +813,10 @@
         "elementType": {
           "$ref": "#/definitions/Schema",
           "description": "the element type of the dictionary. (Keys are always strings)"
+        },
+        "nullableItems": {
+          "description": "if elements in the dictionary should be nullable",
+          "type": "boolean"
         }
       },
       "defaultProperties": [],

--- a/codemodel/.resources/all-in-one/yaml/code-model.yaml
+++ b/codemodel/.resources/all-in-one/yaml/code-model.yaml
@@ -114,6 +114,9 @@ definitions:
       minItems:
         type: number
         description: minimum number of elements in the array
+      nullableItems:
+        type: boolean
+        description: if elements in the array should be nullable
       uniqueItems:
         type: boolean
         description: if the elements in the array should be unique
@@ -546,6 +549,9 @@ definitions:
       elementType:
         description: the element type of the dictionary. (Keys are always strings)
         $ref: '#/definitions/Schema'
+      nullableItems:
+        type: boolean
+        description: if elements in the dictionary should be nullable
     required:
       - elementType
       - language

--- a/codemodel/.resources/model/json/schemas.json
+++ b/codemodel/.resources/model/json/schemas.json
@@ -256,6 +256,10 @@
         "uniqueItems": {
           "description": "if the elements in the array should be unique",
           "type": "boolean"
+        },
+        "nullableItems": {
+          "description": "if elements in the array should be nullable",
+          "type": "boolean"
         }
       },
       "defaultProperties": [],
@@ -306,6 +310,10 @@
         "elementType": {
           "$ref": "./schemas.json#/definitions/Schema",
           "description": "the element type of the dictionary. (Keys are always strings)"
+        },
+        "nullableItems": {
+          "description": "if elements in the dictionary should be nullable",
+          "type": "boolean"
         }
       },
       "defaultProperties": [],

--- a/codemodel/.resources/model/yaml/schemas.yaml
+++ b/codemodel/.resources/model/yaml/schemas.yaml
@@ -25,6 +25,9 @@ definitions:
       minItems:
         type: number
         description: minimum number of elements in the array
+      nullableItems:
+        type: boolean
+        description: if elements in the array should be nullable
       uniqueItems:
         type: boolean
         description: if the elements in the array should be unique
@@ -271,6 +274,9 @@ definitions:
       elementType:
         description: the element type of the dictionary. (Keys are always strings)
         $ref: './schemas.yaml#/definitions/Schema'
+      nullableItems:
+        type: boolean
+        description: if elements in the dictionary should be nullable
     required:
       - elementType
       - language

--- a/codemodel/model/common/schemas/array.ts
+++ b/codemodel/model/common/schemas/array.ts
@@ -19,6 +19,9 @@ export interface ArraySchema<ElementType extends Schema = Schema> extends ValueS
 
   /** if the elements in the array should be unique */
   uniqueItems?: boolean;
+
+  /** if elements in the array should be nullable */
+  nullableItems?: boolean;
 }
 export class ArraySchema<ElementType extends Schema = Schema> extends Schema implements ArraySchema<ElementType>{
   constructor(name: string, description: string, elementType: ElementType, objectInitializer?: DeepPartial<ArraySchema<ElementType>>) {

--- a/codemodel/model/common/schemas/dictionary.ts
+++ b/codemodel/model/common/schemas/dictionary.ts
@@ -9,6 +9,9 @@ export interface DictionarySchema<ElementType extends Schema = Schema> extends C
 
   /** the element type of the dictionary. (Keys are always strings) */
   elementType: ElementType;
+
+  /** if elements in the dictionary should be nullable */
+  nullableItems?: boolean;
 }
 
 export class DictionarySchema<ElementType extends Schema = Schema> extends Schema implements DictionarySchema<ElementType>{


### PR DESCRIPTION
This is needed to enable https://github.com/Azure/autorest.modelerfour/pull/298 for issue https://github.com/Azure/autorest.modelerfour/issues/269.