### PR TITLE
Ensure that x-ms-client-default is copied to OpenAPI 3 document

### DIFF
--- a/oai2-to-oai3/main.ts
+++ b/oai2-to-oai3/main.ts
@@ -238,6 +238,7 @@ export class Oai2ToOai3 {
         'x-comment',
         'x-ms-parameter-grouping',
         'x-ms-client-name',
+        'x-ms-client-default',
         'x-ms-client-flatten',
         'x-ms-client-request-id',
         'x-ms-header-collection-prefix'


### PR DESCRIPTION
This change adds `x-ms-client-default` to the list of properties that are copied across from the Swagger spec to the new OpenAPI v3 document.  It is the first part of the fix for https://github.com/Azure/autorest.modelerfour/issues/268.