### PR TITLE
More x-nullable fixes

### DIFF
--- a/codemodel/.resources/all-in-one/json/code-model.json
+++ b/codemodel/.resources/all-in-one/json/code-model.json
@@ -2013,6 +2013,10 @@
         "schema": {
           "$ref": "#/definitions/Schema",
           "description": "the content returned by the service for a given operaiton"
+        },
+        "nullable": {
+          "description": "indicates whether the response can be 'null'",
+          "type": "boolean"
         }
       },
       "defaultProperties": [],

--- a/codemodel/.resources/all-in-one/yaml/code-model.yaml
+++ b/codemodel/.resources/all-in-one/yaml/code-model.yaml
@@ -1625,6 +1625,9 @@ definitions:
       schema:
         description: the content returned by the service for a given operaiton
         $ref: '#/definitions/Schema'
+      nullable:
+        type: boolean
+        description: indicates whether the response can be 'null'
     required:
       - language
       - protocol

--- a/codemodel/.resources/model/json/master.json
+++ b/codemodel/.resources/model/json/master.json
@@ -736,6 +736,10 @@
         "schema": {
           "$ref": "./schemas.json#/definitions/Schema",
           "description": "the content returned by the service for a given operaiton"
+        },
+        "nullable": {
+          "description": "indicates whether the response can be 'null'",
+          "type": "boolean"
         }
       },
       "defaultProperties": [],

--- a/codemodel/.resources/model/yaml/master.yaml
+++ b/codemodel/.resources/model/yaml/master.yaml
@@ -519,6 +519,9 @@ definitions:
       schema:
         description: the content returned by the service for a given operaiton
         $ref: './schemas.yaml#/definitions/Schema'
+      nullable:
+        type: boolean
+        description: indicates whether the response can be 'null'
     required:
       - language
       - protocol

--- a/codemodel/model/common/response.ts
+++ b/codemodel/model/common/response.ts
@@ -32,6 +32,9 @@ export class BinaryResponse extends Response implements BinaryResponse {
 export interface SchemaResponse extends Response {
   /** the content returned by the service for a given operaiton */
   schema: Schema;
+
+  /** indicates whether the response can be 'null' */
+  nullable?: boolean;
 }
 
 export class SchemaResponse extends Response implements SchemaResponse {

--- a/oai2-to-oai3/main.ts
+++ b/oai2-to-oai3/main.ts
@@ -531,13 +531,13 @@ export class Oai2ToOai3 {
           target.example = { value, pointer, recurse: true };
           break;
         case 'x-nullable':
-          // NOTE: this matches the previous converter behavior
-          // ... when a $ref is inside the schema
-          // copy the properties as they are
-          // don't update names
-          if (schemaValue.$ref === undefined) {
-            target['nullable'] = { value, pointer };
-          } else {
+          target['nullable'] = { value, pointer };
+
+          // NOTE: this matches the previous converter behavior ... when a $ref
+          // is inside the schema copy the properties as they are don't update
+          // names, but also leave the new `nullable` field so that OpenAPI 3
+          // readers pick it up correctly.
+          if (schemaValue.$ref !== undefined) {
             target['x-nullable'] = { value, pointer };
           }
           break;


### PR DESCRIPTION
This PR fixes another issue with `x-nullable` propagation in `oai2-to-oai3` and adds a `nullable?` property to `CodeModel`'s `SchemaResponse` so that schema responses can be nullable.