### PR TITLE
Fix collection style issues in oai2-to-oai3 and codemodel

### DIFF
--- a/codemodel/.resources/all-in-one/json/code-model.json
+++ b/codemodel/.resources/all-in-one/json/code-model.json
@@ -2687,6 +2687,10 @@
           "$ref": "#/definitions/SerializationStyle",
           "description": "the Serialization Style used for the parameter."
         },
+        "explode": {
+          "description": "when set, 'form' style parameters generate separate parameters for each value of an array.",
+          "type": "boolean"
+        },
         "skipUriEncoding": {
           "description": "when set, this indicates that the content of the parameter should not be subject to URI encoding rules.",
           "type": "boolean"

--- a/codemodel/.resources/all-in-one/yaml/code-model.yaml
+++ b/codemodel/.resources/all-in-one/yaml/code-model.yaml
@@ -825,6 +825,9 @@ definitions:
     allOf:
       - $ref: '#/definitions/Protocol'
     properties:
+      explode:
+        type: boolean
+        description: 'when set, ''form'' style parameters generate separate parameters for each value of an array.'
       in:
         description: the location that this parameter is placed in the http request
         $ref: '#/definitions/ParameterLocation'

--- a/codemodel/.resources/model/json/http.json
+++ b/codemodel/.resources/model/json/http.json
@@ -326,6 +326,10 @@
           "$ref": "./enums.json#/definitions/SerializationStyle",
           "description": "the Serialization Style used for the parameter."
         },
+        "explode": {
+          "description": "when set, 'form' style parameters generate separate parameters for each value of an array.",
+          "type": "boolean"
+        },
         "skipUriEncoding": {
           "description": "when set, this indicates that the content of the parameter should not be subject to URI encoding rules.",
           "type": "boolean"

--- a/codemodel/.resources/model/yaml/http.yaml
+++ b/codemodel/.resources/model/yaml/http.yaml
@@ -218,6 +218,9 @@ definitions:
     allOf:
       - $ref: './master.yaml#/definitions/Protocol'
     properties:
+      explode:
+        type: boolean
+        description: 'when set, ''form'' style parameters generate separate parameters for each value of an array.'
       in:
         description: the location that this parameter is placed in the http request
         $ref: './enums.yaml#/definitions/ParameterLocation'

--- a/codemodel/model/http/http.ts
+++ b/codemodel/model/http/http.ts
@@ -17,6 +17,9 @@ export interface HttpParameter extends Protocol {
   /** the Serialization Style used for the parameter. */
   style?: SerializationStyle;
 
+  /** when set, 'form' style parameters generate separate parameters for each value of an array. */
+  explode?: boolean;
+
   /** when set, this indicates that the content of the parameter should not be subject to URI encoding rules. */
   skipUriEncoding?: boolean;
 }

--- a/oai2-to-oai3/main.ts
+++ b/oai2-to-oai3/main.ts
@@ -259,7 +259,8 @@ export class Oai2ToOai3 {
       }
 
       // Collection Format
-      if (parameterValue.collectionFormat !== undefined && parameterValue.type === 'array') {
+      if (parameterValue.type === 'array') {
+        parameterValue.collectionFormat = parameterValue.collectionFormat || 'csv';
         if ((parameterValue.collectionFormat === 'csv') && ((parameterValue.in === 'query') || (parameterValue.in === 'cookie'))) {
           parameterTarget.style = { value: 'form', pointer };
         }


### PR DESCRIPTION
This change addresses a couple of issues that @lmazuel identified with how we handle `collectionFormat`

- https://github.com/Azure/perks/issues/117 - When `collectionFormat` isn't specified, we don't set the parameter `style` correctly.  We now default `collectionFormat` to `csv` for `array` parameters when it hasn't been specified.
- https://github.com/Azure/autorest.modelerfour/issues/314 - The `explode` parameter that pairs with `style` in OpenAPI 3 needs to be added to `HttpParameter` in `CodeModel` so that generators can distinguish between exploded and non-exploded `form` collections.

The latter issue will need a corresponding change in modelerfour before it's fully fixed.