### PR TITLE
Add 'language' field to HttpHeader for name and description

### DIFF
--- a/codemodel/.resources/all-in-one/json/code-model.json
+++ b/codemodel/.resources/all-in-one/json/code-model.json
@@ -2875,6 +2875,9 @@
         "schema": {
           "$ref": "#/definitions/Schema"
         },
+        "language": {
+          "$ref": "#/definitions/Languages"
+        },
         "extensions": {
           "$ref": "#/definitions/Dictionary<any>",
           "description": "additional metadata extensions dictionary"

--- a/codemodel/.resources/all-in-one/yaml/code-model.yaml
+++ b/codemodel/.resources/all-in-one/yaml/code-model.yaml
@@ -726,6 +726,8 @@ definitions:
       extensions:
         description: additional metadata extensions dictionary
         $ref: '#/definitions/Dictionary<any>'
+      language:
+        $ref: '#/definitions/Languages'
     required:
       - header
       - schema

--- a/codemodel/.resources/model/json/http.json
+++ b/codemodel/.resources/model/json/http.json
@@ -514,6 +514,9 @@
         "schema": {
           "$ref": "./schemas.json#/definitions/Schema"
         },
+        "language": {
+          "$ref": "./master.json#/definitions/Languages"
+        },
         "extensions": {
           "$ref": "./master.json#/definitions/Dictionary<any>",
           "description": "additional metadata extensions dictionary"

--- a/codemodel/.resources/model/yaml/http.yaml
+++ b/codemodel/.resources/model/yaml/http.yaml
@@ -131,6 +131,8 @@ definitions:
       extensions:
         description: additional metadata extensions dictionary
         $ref: './master.yaml#/definitions/Dictionary<any>'
+      language:
+        $ref: './master.yaml#/definitions/Languages'
     required:
       - header
       - schema

--- a/codemodel/model/http/http.ts
+++ b/codemodel/model/http/http.ts
@@ -8,6 +8,7 @@ import { Schema } from '../common/schema';
 import { DeepPartial, KnownMediaType, Initializer } from '@azure-tools/codegen';
 import { Extensions } from '../common/extensions';
 import { GroupSchema } from '../common/schemas/object';
+import { Languages } from '../common/languages';
 
 /** extended metadata for HTTP operation parameters  */
 export interface HttpParameter extends Protocol {
@@ -92,6 +93,7 @@ export class HttpMultipartRequest extends HttpWithBodyRequest implements HttpMul
 export interface HttpHeader extends Extensions {
   header: string;
   schema: Schema;
+  language?: Languages;
 }
 export class HttpHeader extends Initializer implements HttpHeader {
   constructor(public header: string, public schema: Schema, objectInitializer?: DeepPartial<HttpHeader>) {


### PR DESCRIPTION
This change adds a `language: Language` field to `HttpHeader` so that we can gather `name` and `description` from response headers.  This will be used to pull `x-ms-client-name` or the `header` name itself as `name` in modelerfour.