### PR TITLE
Make HttpHeader language property required for consistency

### DIFF
--- a/codemodel/.resources/all-in-one/json/code-model.json
+++ b/codemodel/.resources/all-in-one/json/code-model.json
@@ -2887,6 +2887,7 @@
       "additionalProperties": false,
       "required": [
         "header",
+        "language",
         "schema"
       ]
     },

--- a/codemodel/.resources/all-in-one/yaml/code-model.yaml
+++ b/codemodel/.resources/all-in-one/yaml/code-model.yaml
@@ -730,6 +730,7 @@ definitions:
         $ref: '#/definitions/Languages'
     required:
       - header
+      - language
       - schema
   HttpMethod:
     type: string

--- a/codemodel/.resources/model/json/http.json
+++ b/codemodel/.resources/model/json/http.json
@@ -526,6 +526,7 @@
       "additionalProperties": false,
       "required": [
         "header",
+        "language",
         "schema"
       ]
     },

--- a/codemodel/.resources/model/yaml/http.yaml
+++ b/codemodel/.resources/model/yaml/http.yaml
@@ -135,6 +135,7 @@ definitions:
         $ref: './master.yaml#/definitions/Languages'
     required:
       - header
+      - language
       - schema
   HttpModel:
     type: object

--- a/codemodel/model/http/http.ts
+++ b/codemodel/model/http/http.ts
@@ -93,7 +93,7 @@ export class HttpMultipartRequest extends HttpWithBodyRequest implements HttpMul
 export interface HttpHeader extends Extensions {
   header: string;
   schema: Schema;
-  language?: Languages;
+  language: Languages;
 }
 export class HttpHeader extends Initializer implements HttpHeader {
   constructor(public header: string, public schema: Schema, objectInitializer?: DeepPartial<HttpHeader>) {


### PR DESCRIPTION
Should have done this in PR #121 to be consistent with other instances of `language`, thanks to @pakrym for pointing it out.