### PR TITLE
Convert formData "file" types to binary-format string types

### DIFF
--- a/oai2-to-oai3/test/resources/conversion/oai3/openapi.yaml
+++ b/oai2-to-oai3/test/resources/conversion/oai3/openapi.yaml
@@ -452,7 +452,8 @@
                   },
                   "file": {
                     "description": "file to upload",
-                    "type": "file"
+                    "format": "binary",
+                    "type": "string"
                   }
                 },
                 "required": []

--- a/oai2-to-oai3/test/resources/conversion/oai3/request-body-openapi.yaml
+++ b/oai2-to-oai3/test/resources/conversion/oai3/request-body-openapi.yaml
@@ -65,7 +65,8 @@ paths:
               properties:
                 form_part_1:
                   description: A file transmitted via a mimepart within a multipart form.
-                  type: file
+                  format: binary
+                  type: string
                   x-file-content-types:
                     - application/zip
                     - application/octet-stream
@@ -97,7 +98,8 @@ paths:
               properties:
                 part_1:
                   description: A file transmitted via a mimepart within a multipart form.
-                  type: file
+                  format: binary
+                  type: string
                   x-file-content-types:
                     - application/gzip
                     - application/jpg


### PR DESCRIPTION
This change enables us to convert the `file` type of `formData` parameters to `type: string, format: binary` with is required by OpenAPI v3.  It also converts file array parameters in OpenAPI v2 (enabled by https://github.com/Azure/autorest/pull/3553) to arrays of the corresponding OpenAPI v3 type.