### PR TITLE
Add 'text' field to XmlSerializationFormat

### DIFF
--- a/codemodel/.resources/all-in-one/json/code-model.json
+++ b/codemodel/.resources/all-in-one/json/code-model.json
@@ -430,12 +430,16 @@
         },
         "wrapped": {
           "type": "boolean"
+        },
+        "text": {
+          "type": "boolean"
         }
       },
       "defaultProperties": [],
       "additionalProperties": false,
       "required": [
         "attribute",
+        "text",
         "wrapped"
       ],
       "allOf": [

--- a/codemodel/.resources/all-in-one/yaml/code-model.yaml
+++ b/codemodel/.resources/all-in-one/yaml/code-model.yaml
@@ -2211,10 +2211,13 @@ definitions:
         type: string
       prefix:
         type: string
+      text:
+        type: boolean
       wrapped:
         type: boolean
     required:
       - attribute
+      - text
       - wrapped
   XorSchema:
     type: object

--- a/codemodel/.resources/model/json/master.json
+++ b/codemodel/.resources/model/json/master.json
@@ -238,12 +238,16 @@
         },
         "wrapped": {
           "type": "boolean"
+        },
+        "text": {
+          "type": "boolean"
         }
       },
       "defaultProperties": [],
       "additionalProperties": false,
       "required": [
         "attribute",
+        "text",
         "wrapped"
       ],
       "allOf": [

--- a/codemodel/.resources/model/yaml/master.yaml
+++ b/codemodel/.resources/model/yaml/master.yaml
@@ -656,10 +656,13 @@ definitions:
         type: string
       prefix:
         type: string
+      text:
+        type: boolean
       wrapped:
         type: boolean
     required:
       - attribute
+      - text
       - wrapped
   email:
     type: string

--- a/codemodel/model/common/formats/xml.ts
+++ b/codemodel/model/common/formats/xml.ts
@@ -1,4 +1,4 @@
-import { SerializationFormat } from '../schema';
+import { SerializationFormat } from "../schema";
 
 export interface XmlSerlializationFormat extends SerializationFormat {
   name?: string;
@@ -6,4 +6,5 @@ export interface XmlSerlializationFormat extends SerializationFormat {
   prefix?: string;
   attribute: boolean;
   wrapped: boolean;
+  text: boolean;
 }


### PR DESCRIPTION
This change adds a `text` field to `XmlSerializationFormat` that will be populated by modelerfour when the `x-ms-text` extension is used inside of the `xml` object of a schema property.

@pakrym @lmazuel - do you think it makes sense for both `attribute` and `xml` to be required?  Making `attribute` non-required now might be considered a breaking change, but I'm not sure.