### PR TITLE
Fix casing of HttpMultipartRequest class to fix schema issue

### DIFF
--- a/codemodel/.resources/all-in-one/json/code-model.json
+++ b/codemodel/.resources/all-in-one/json/code-model.json
@@ -2797,7 +2797,7 @@
         }
       ]
     },
-    "HttpMultiPartRequest": {
+    "HttpMultipartRequest": {
       "type": "object",
       "properties": {
         "multipart": {
@@ -2822,52 +2822,6 @@
         {
           "$ref": "#/definitions/HttpWithBodyRequest"
         }
-      ]
-    },
-    "HttpMultipartRequest": {
-      "type": "object",
-      "properties": {
-        "multipart": {
-          "description": "indicates that the HTTP Request should be a multipart request \n\nie, that it has multiple requests in a single request.",
-          "type": "boolean",
-          "enum": [
-            true
-          ],
-          "default": true
-        },
-        "knownMediaType": {
-          "$ref": "#/definitions/KnownMediaType",
-          "description": "a normalized value for the media type (ie, distills down to a well-known moniker (ie, 'json'))"
-        },
-        "mediaTypes": {
-          "description": "must contain at least one media type to send for the body",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "path": {
-          "description": "A relative path to an individual endpoint. \n\nThe field name MUST begin with a slash. \nThe path is appended (no relative URL resolution) to the expanded URL from the Server Object's url field in order to construct the full URL. \nPath templating is allowed. \n\nWhen matching URLs, concrete (non-templated) paths would be matched before their templated counterparts.",
-          "type": "string"
-        },
-        "uri": {
-          "description": "the base URI template for the operation. This will be a template that has Uri parameters to craft the base url to use.",
-          "type": "string"
-        },
-        "method": {
-          "$ref": "#/definitions/HttpMethod",
-          "description": "the HTTP Method used to process this operation"
-        }
-      },
-      "defaultProperties": [],
-      "additionalProperties": false,
-      "required": [
-        "knownMediaType",
-        "mediaTypes",
-        "method",
-        "multipart",
-        "path",
-        "uri"
       ]
     },
     "HttpHeader": {

--- a/codemodel/.resources/all-in-one/yaml/code-model.yaml
+++ b/codemodel/.resources/all-in-one/yaml/code-model.yaml
@@ -756,7 +756,7 @@ definitions:
         description: a collection of security requirements for the service
         items:
           $ref: '#/definitions/SecurityRequirement'
-  HttpMultiPartRequest:
+  HttpMultipartRequest:
     type: object
     additionalProperties: false
     allOf:
@@ -770,50 +770,6 @@ definitions:
           ie, that it has multiple requests in a single request.
         enum:
           - true
-    required:
-      - knownMediaType
-      - mediaTypes
-      - method
-      - multipart
-      - path
-      - uri
-  HttpMultipartRequest:
-    type: object
-    additionalProperties: false
-    properties:
-      path:
-        type: string
-        description: |-
-          A relative path to an individual endpoint. 
-
-          The field name MUST begin with a slash. 
-          The path is appended (no relative URL resolution) to the expanded URL from the Server Object's url field in order to construct the full URL. 
-          Path templating is allowed. 
-
-          When matching URLs, concrete (non-templated) paths would be matched before their templated counterparts.
-      method:
-        description: the HTTP Method used to process this operation
-        $ref: '#/definitions/HttpMethod'
-      knownMediaType:
-        description: 'a normalized value for the media type (ie, distills down to a well-known moniker (ie, ''json''))'
-        $ref: '#/definitions/KnownMediaType'
-      mediaTypes:
-        type: array
-        description: must contain at least one media type to send for the body
-        items:
-          type: string
-      multipart:
-        type: boolean
-        description: |-
-          indicates that the HTTP Request should be a multipart request 
-
-          ie, that it has multiple requests in a single request.
-        default: true
-        enum:
-          - true
-      uri:
-        type: string
-        description: the base URI template for the operation. This will be a template that has Uri parameters to craft the base url to use.
     required:
       - knownMediaType
       - mediaTypes

--- a/codemodel/.resources/model/json/http.json
+++ b/codemodel/.resources/model/json/http.json
@@ -432,7 +432,7 @@
         }
       ]
     },
-    "HttpMultiPartRequest": {
+    "HttpMultipartRequest": {
       "type": "object",
       "properties": {
         "multipart": {
@@ -457,52 +457,6 @@
         {
           "$ref": "./http.json#/definitions/HttpWithBodyRequest"
         }
-      ]
-    },
-    "HttpMultipartRequest": {
-      "type": "object",
-      "properties": {
-        "multipart": {
-          "description": "indicates that the HTTP Request should be a multipart request \n\nie, that it has multiple requests in a single request.",
-          "type": "boolean",
-          "enum": [
-            true
-          ],
-          "default": true
-        },
-        "knownMediaType": {
-          "$ref": "./enums.json#/definitions/KnownMediaType",
-          "description": "a normalized value for the media type (ie, distills down to a well-known moniker (ie, 'json'))"
-        },
-        "mediaTypes": {
-          "description": "must contain at least one media type to send for the body",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "path": {
-          "description": "A relative path to an individual endpoint. \n\nThe field name MUST begin with a slash. \nThe path is appended (no relative URL resolution) to the expanded URL from the Server Object's url field in order to construct the full URL. \nPath templating is allowed. \n\nWhen matching URLs, concrete (non-templated) paths would be matched before their templated counterparts.",
-          "type": "string"
-        },
-        "uri": {
-          "description": "the base URI template for the operation. This will be a template that has Uri parameters to craft the base url to use.",
-          "type": "string"
-        },
-        "method": {
-          "$ref": "./enums.json#/definitions/HttpMethod",
-          "description": "the HTTP Method used to process this operation"
-        }
-      },
-      "defaultProperties": [],
-      "additionalProperties": false,
-      "required": [
-        "knownMediaType",
-        "mediaTypes",
-        "method",
-        "multipart",
-        "path",
-        "uri"
       ]
     },
     "HttpHeader": {

--- a/codemodel/.resources/model/yaml/http.yaml
+++ b/codemodel/.resources/model/yaml/http.yaml
@@ -149,7 +149,7 @@ definitions:
         description: a collection of security requirements for the service
         items:
           $ref: './http.yaml#/definitions/SecurityRequirement'
-  HttpMultiPartRequest:
+  HttpMultipartRequest:
     type: object
     additionalProperties: false
     allOf:
@@ -163,50 +163,6 @@ definitions:
           ie, that it has multiple requests in a single request.
         enum:
           - true
-    required:
-      - knownMediaType
-      - mediaTypes
-      - method
-      - multipart
-      - path
-      - uri
-  HttpMultipartRequest:
-    type: object
-    additionalProperties: false
-    properties:
-      path:
-        type: string
-        description: |-
-          A relative path to an individual endpoint. 
-
-          The field name MUST begin with a slash. 
-          The path is appended (no relative URL resolution) to the expanded URL from the Server Object's url field in order to construct the full URL. 
-          Path templating is allowed. 
-
-          When matching URLs, concrete (non-templated) paths would be matched before their templated counterparts.
-      method:
-        description: the HTTP Method used to process this operation
-        $ref: './enums.yaml#/definitions/HttpMethod'
-      knownMediaType:
-        description: 'a normalized value for the media type (ie, distills down to a well-known moniker (ie, ''json''))'
-        $ref: './enums.yaml#/definitions/KnownMediaType'
-      mediaTypes:
-        type: array
-        description: must contain at least one media type to send for the body
-        items:
-          type: string
-      multipart:
-        type: boolean
-        description: |-
-          indicates that the HTTP Request should be a multipart request 
-
-          ie, that it has multiple requests in a single request.
-        default: true
-        enum:
-          - true
-      uri:
-        type: string
-        description: the base URI template for the operation. This will be a template that has Uri parameters to craft the base url to use.
     required:
       - knownMediaType
       - mediaTypes

--- a/codemodel/model/http/http.ts
+++ b/codemodel/model/http/http.ts
@@ -77,7 +77,7 @@ export interface HttpBinaryRequest extends HttpWithBodyRequest {
 export class HttpBinaryRequest extends HttpWithBodyRequest implements HttpBinaryRequest {
 }
 
-export interface HttpMultiPartRequest extends HttpWithBodyRequest {
+export interface HttpMultipartRequest extends HttpWithBodyRequest {
   /** indicates that the HTTP Request should be a multipart request 
    * 
    * ie, that it has multiple requests in a single request.
@@ -86,7 +86,7 @@ export interface HttpMultiPartRequest extends HttpWithBodyRequest {
 }
 
 
-export class HttpMultipartRequest extends HttpWithBodyRequest implements HttpMultiPartRequest {
+export class HttpMultipartRequest extends HttpWithBodyRequest implements HttpMultipartRequest {
   multipart = <true>true;
 }
 


### PR DESCRIPTION
Because the casing of the class `HttpMultiPartRequest` and the interface `HttpMultipartRequest` were different, the generated schemas ended up treating them as two separate types.  This caused an issue for @ShivangiReja when she tried to deserialize a code model with `HttpMultipartRequest` because the concrete type did not inherit from `HttpWithBodyRequest`.  Changing the casing to be consistent has put those two types back together as one now which should fix the issue.