### PR TITLE
Add support for date-based versions with the form YYYY-MM

### DIFF
--- a/codegen/apiversion.ts
+++ b/codegen/apiversion.ts
@@ -4,6 +4,8 @@ import * as semver from 'semver';
 /*
  Handling:
 
+ yyyy-mm                      n(yyyy).n(mm).0
+ yyyy-mm-preview              n(yyyy).n(mm).0-preview
  yyyy-mm-dd                   n(yyyy).n(mm).n(dd)
  yyyy-mm-dd-preview           n(yyyy).n(mm).n(dd)-preview
  yyyy-mm-dd.x1.x2             (miliseconds since 1970-01-01).x1.x2
@@ -26,7 +28,7 @@ export function toSemver(apiversion: string) {
     const lastNumbers = apiversion.replace(versionedDateRegex, '$2');
     return `${miliseconds}${lastNumbers}`;
   }
-  const [whole, major, minor, revision, tag] = /^(\d+)-(\d+)-(\d+)(.*)/.exec(apiversion) || /(\d*)\.(\d*)\.(\d*)(.*)/.exec(apiversion) || /(\d*)\.(\d*)()(.*)/.exec(apiversion) || /(\d*)()()(.*)/.exec(apiversion) || [];
+  const [whole, major, minor, revision, tag] = /^(\d+)-(\d+)(?:-(\d+))?(.*)/.exec(apiversion) || /(\d*)\.(\d*)\.(\d*)(.*)/.exec(apiversion) || /(\d*)\.(\d*)()(.*)/.exec(apiversion) || /(\d*)()()(.*)/.exec(apiversion) || [];
   return `${Number.parseInt(major || '0') || 0}.${Number.parseInt(minor || '0') || 0}.${Number.parseInt(revision || '0') || 0}${tag?.startsWith('-') ? tag : ''}`;
 }
 

--- a/codegen/test/test-async.ts
+++ b/codegen/test/test-async.ts
@@ -33,6 +33,14 @@ import { toSemver } from '../apiversion';
     const expected7 = '1.3.1';
     assert.strictEqual(actual7, expected7);
 
+    const actual8 = toSemver('2020-09');
+    const expected8 = '2020.9.0';
+    assert.strictEqual(actual8, expected8);
+
+    const actual9 = toSemver('2020-09-preview');
+    const expected9 = '2020.9.0-preview';
+    assert.strictEqual(actual9, expected9);
+
     assert.strictEqual(toSemver('v1'), '1.0.0');
 
     assert.strictEqual(toSemver('3.0-preview.1'), '3.0.0-preview.1');


### PR DESCRIPTION
This change updates the logic for converting date-based versions to SemVer 2.0 strings such that it now supports date versions formatted with only the year and month (YYYY-MM).  This is necessary for the rare service which encodes versions in this way.  When converting such a version, a zero (`0`) is used for the patch version number.