### PR TITLE
Allow github.com url for private repos

### DIFF
--- a/datastore/file-system.ts
+++ b/datastore/file-system.ts
@@ -95,7 +95,11 @@ export class EnhancedFileSystem implements IFileSystem {
     const headers: { [key: string]: string } = {};
 
     // check for GitHub OAuth token
-    if (this.githubAuthToken && uri.startsWith('https://raw.githubusercontent.com')) {
+    if (
+      this.githubAuthToken &&
+        (uri.startsWith('https://raw.githubusercontent.com') ||
+        uri.startsWith('https://github.com'))
+    ) {
       console.log(`Used GitHub authentication token to request '${uri}'.`);
       headers.authorization = `Bearer ${this.githubAuthToken}`;
     }


### PR DESCRIPTION
When referencing to a github.com url it wasn't adding the authentication information if present.

fix Azure/autorest#3368 issue with using `github.com` instead of `raw.githubusercontent.com` for private repos 
