### PR TITLE
Reenable line indexing to fix issue where all logged errors are reported as being at 1:1

### DIFF
--- a/datastore/data-store/data-store.ts
+++ b/datastore/data-store/data-store.ts
@@ -26,11 +26,11 @@ const FALLBACK_DEFAULT_OUTPUT_ARTIFACT = '';
  ********************************************/
 
 export interface Metadata {
-  inputSourceMap: LazyPromise<RawSourceMap>;
   lineIndices: Lazy<Array<number>>;
-
-  sourceMap: LazyPromise<RawSourceMap>;
-  sourceMapEachMappingByLine: LazyPromise<Array<Array<MappingItem>>>;
+  
+  // inputSourceMap: LazyPromise<RawSourceMap>;
+  // sourceMap: LazyPromise<RawSourceMap>;
+  // sourceMapEachMappingByLine: LazyPromise<Array<Array<MappingItem>>>;
 }
 
 export interface Data {
@@ -235,44 +235,44 @@ export class DataStore {
 
     // metadata.artifactType = artifact;
 
-    metadata.sourceMap = new LazyPromise(async () => {
-      if (!sourceMapFactory) {
-        return new SourceMapGenerator().toJSON();
-      }
-      const sourceMap = await sourceMapFactory(result);
+    // metadata.sourceMap = new LazyPromise(async () => {
+    //   if (!sourceMapFactory) {
+    //     return new SourceMapGenerator().toJSON();
+    //   }
+    //   const sourceMap = await sourceMapFactory(result);
 
-      // validate
-      const inputFiles = sourceMap.sources.concat(sourceMap.file);
-      for (const inputFile of inputFiles) {
-        if (!this.store[inputFile]) {
-          throw new Error(`Source map of '${uri}' references '${inputFile}' which does not exist`);
-        }
-      }
+    //   // validate
+    //   const inputFiles = sourceMap.sources.concat(sourceMap.file);
+    //   for (const inputFile of inputFiles) {
+    //     if (!this.store[inputFile]) {
+    //       throw new Error(`Source map of '${uri}' references '${inputFile}' which does not exist`);
+    //     }
+    //   }
 
-      return sourceMap;
-    });
+    //   return sourceMap;
+    // });
 
 
-    metadata.sourceMapEachMappingByLine = new LazyPromise<Array<Array<MappingItem>>>(async () => {
-      const result: Array<Array<MappingItem>> = [];
+    // metadata.sourceMapEachMappingByLine = new LazyPromise<Array<Array<MappingItem>>>(async () => {
+    //   const result: Array<Array<MappingItem>> = [];
 
-      const sourceMapConsumer = new SourceMapConsumer(await metadata.sourceMap);
+    //   const sourceMapConsumer = new SourceMapConsumer(await metadata.sourceMap);
 
-      // does NOT support multiple sources :(
-      // `singleResult` has null-properties if there is no original
+    //   // does NOT support multiple sources :(
+    //   // `singleResult` has null-properties if there is no original
 
-      // get coinciding sources
-      sourceMapConsumer.eachMapping(mapping => {
-        while (result.length <= mapping.generatedLine) {
-          result.push([]);
-        }
-        result[mapping.generatedLine].push(mapping);
-      });
+    //   // get coinciding sources
+    //   sourceMapConsumer.eachMapping(mapping => {
+    //     while (result.length <= mapping.generatedLine) {
+    //       result.push([]);
+    //     }
+    //     result[mapping.generatedLine].push(mapping);
+    //   });
 
-      return result;
-    });
+    //   return result;
+    // });
 
-    metadata.inputSourceMap = new LazyPromise(() => this.CreateInputSourceMapFor(uri));
+    // metadata.inputSourceMap = new LazyPromise(() => this.CreateInputSourceMapFor(uri));
     metadata.lineIndices = new Lazy<Array<number>>(() => LineIndices(data));
 
     return result;
@@ -320,7 +320,7 @@ export class DataStore {
       name: `blameRoot (${JSON.stringify(position)})`
     });
   }
-
+  /* DISABLING SOURCE MAP SUPPORT 
   private async CreateInputSourceMapFor(absoluteUri: string): Promise<RawSourceMap> {
     const data = this.ReadStrictSync(absoluteUri);
 
@@ -345,9 +345,10 @@ export class DataStore {
       }
     }
     const sourceMapGenerator = new SourceMapGenerator({ file: absoluteUri });
-    await Compile(mappings, sourceMapGenerator);
+    Compile(mappings, sourceMapGenerator);
     return sourceMapGenerator.toJSON();
   }
+  */
 }
 
 /********************************************

--- a/datastore/data-store/data-store.ts
+++ b/datastore/data-store/data-store.ts
@@ -201,7 +201,7 @@ export class DataStore {
 
   private uid = 0;
 
-  private async WriteDataInternal(uri: string, data: string, artifactType: string, identity: Array<string>): Promise<DataHandle> {
+  private async WriteDataInternal(uri: string, data: string, artifactType: string, identity: Array<string>, metadata: Metadata): Promise<DataHandle> {
     this.ThrowIfCancelled();
     if (this.store[uri]) {
       throw new Error(`can only write '${uri}' once`);
@@ -218,8 +218,9 @@ export class DataStore {
       name,
       cached: data,
       artifactType,
-      identity
-    } as any;
+      identity,
+      metadata,
+    };
 
     return this.Read(uri);
   }
@@ -230,7 +231,7 @@ export class DataStore {
     // metadata
     const metadata: Metadata = {} as any;
 
-    const result = await this.WriteDataInternal(uri, data, artifact, identity);
+    const result = await this.WriteDataInternal(uri, data, artifact, identity, metadata);
 
     // metadata.artifactType = artifact;
 
@@ -274,7 +275,6 @@ export class DataStore {
     metadata.inputSourceMap = new LazyPromise(() => this.CreateInputSourceMapFor(uri));
     metadata.lineIndices = new Lazy<Array<number>>(() => LineIndices(data));
 
-    result.metadata = metadata;
     return result;
   }
 
@@ -490,10 +490,6 @@ export class DataHandle {
     return this.item.metadata;
   }
 
-  public set metadata(value: Metadata) {
-    this.item.metadata  = value;
-  }
-  
   public get artifactType(): string {
     return this.item.artifactType;
   }

--- a/datastore/parsing/text-utility.ts
+++ b/datastore/parsing/text-utility.ts
@@ -8,6 +8,10 @@ import { Position as sourceMapPosition } from "source-map";
 
 const regexNewLine = /\r?\n/g;
 
+/**
+ * Return an array containg the indexes where each line start. Each cell has the index to its coresponding line.
+ * @param text Text to index.
+ */
 export function LineIndices(text: string): Array<number> {
   const indices = [0];
 

--- a/datastore/parsing/text-utility.ts
+++ b/datastore/parsing/text-utility.ts
@@ -25,11 +25,14 @@ export function Lines(text: string): Array<string> {
 
 const top = { column: 1, line: 1 };
 
+/**
+ * Retrieve the position(Line,Column) from the index in the source.
+ * @param text Source.
+ * @param index Index.
+ */
 export function IndexToPosition(text: DataHandle | string, index: number): sourceMapPosition {
-  return top;
-  /*  DISABLING SOURCE-MAP-SUPPORT 
   const startIndices = typeof text === "string" ? LineIndices(text) : text.metadata.lineIndices.Value;
-  
+
   // bin. search for last `<item> <= index`
   let lineIndexMin = 0;
   let lineIndexMax = startIndices.length;
@@ -46,5 +49,4 @@ export function IndexToPosition(text: DataHandle | string, index: number): sourc
     column: index - startIndices[lineIndexMin],
     line: 1 + lineIndexMin,
   };
-  */
 }

--- a/datastore/parsing/text-utility.ts
+++ b/datastore/parsing/text-utility.ts
@@ -3,8 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { DataHandle } from '../data-store/data-store';
-import { Position as sourceMapPosition } from 'source-map';
+import { DataHandle } from "../data-store/data-store";
+import { Position as sourceMapPosition } from "source-map";
 
 const regexNewLine = /\r?\n/g;
 
@@ -30,14 +30,20 @@ const top = { column: 1, line: 1 };
  * @param text Source.
  * @param index Index.
  */
-export function IndexToPosition(text: DataHandle | string, index: number): sourceMapPosition {
-  const startIndices = typeof text === "string" ? LineIndices(text) : text.metadata.lineIndices.Value;
+export function IndexToPosition(
+  text: DataHandle | string,
+  index: number
+): sourceMapPosition {
+  const startIndices =
+    typeof text === "string"
+      ? LineIndices(text)
+      : text.metadata.lineIndices.Value;
 
   // bin. search for last `<item> <= index`
   let lineIndexMin = 0;
   let lineIndexMax = startIndices.length;
   while (lineIndexMin < lineIndexMax - 1) {
-    const lineIndex = (lineIndexMin + lineIndexMax) / 2 | 0;
+    const lineIndex = ((lineIndexMin + lineIndexMax) / 2) | 0;
     if (startIndices[lineIndex] <= index) {
       lineIndexMin = lineIndex;
     } else {

--- a/datastore/parsing/text-utility.ts
+++ b/datastore/parsing/text-utility.ts
@@ -23,8 +23,6 @@ export function Lines(text: string): Array<string> {
   return text.split(regexNewLine);
 }
 
-const top = { column: 1, line: 1 };
-
 /**
  * Retrieve the position(Line,Column) from the index in the source.
  * @param text Source.


### PR DESCRIPTION
Seems like the sourcemapping code was disabled. Not sure why. This reenable only the lines index to solve the issue where errors would always show as being on line `1:1`

fix Azure/autorest#3733