### PR TITLE
Update yaml-ast-parser to fix issue with emoji in description

### DIFF
--- a/datastore/package.json
+++ b/datastore/package.json
@@ -57,7 +57,7 @@
     "@azure-tools/codegen": "~2.5.0",
     "jsonpath": "1.0.0",
     "source-map": "0.5.6",
-    "yaml-ast-parser": "0.0.40",
+    "yaml-ast-parser": "0.0.43",
     "js-yaml": "3.13.1"
   }
 }


### PR DESCRIPTION
Using an older version of `yaml-ast-parser` which caused parsing errors showing the wrong position for the error as well and made it very confusing.

Solves issue with the file used in this issue Azure/autorest#3606