### PR TITLE
Yarn/Npm package manager log cmd stdout/stderr on failure

### DIFF
--- a/extension/src/exec-cmd.ts
+++ b/extension/src/exec-cmd.ts
@@ -9,6 +9,11 @@ interface MoreOptions extends SpawnOptions {
 export interface ExecResult {
   stdout: string;
   stderr: string;
+  
+  /**
+   * Union of stdout and stderr.
+   */
+  log: string;
   error: Error | null;
   code: number;
 }
@@ -29,19 +34,23 @@ export const execute = (
 
     let err = "";
     let out = "";
+    let all = "";
     cp.stderr.on("data", (chunk) => {
       err += chunk;
+      all += chunk;
     });
     cp.stdout.on("data", (chunk) => {
       out += chunk;
+      all += chunk;
     });
     cp.on("close", (code, signal) =>
       r({
         stdout: out,
         stderr: err,
+        log: all,
         error: code ? new Error("Process Failed.") : null,
         code,
-      })
+      }),
     );
   });
 };

--- a/extension/src/npm.ts
+++ b/extension/src/npm.ts
@@ -36,6 +36,10 @@ export class Npm implements PackageManager {
       ...packages
     );
     if (output.error) {
+      console.error("NPM log:");
+      console.log("-".repeat(50));
+      console.error(output.log);
+      console.log("-".repeat(50));
       throw Error(`Failed to install package '${packages}' -- ${output.error}`);
     }
   }

--- a/extension/src/yarn.ts
+++ b/extension/src/yarn.ts
@@ -55,6 +55,10 @@ export class Yarn implements PackageManager {
       ...packages
     );
     if (output.error) {
+      console.error("Yarn log:");
+      console.log("-".repeat(50));
+      console.error(output.log);
+      console.log("-".repeat(50));
       throw Error(`Failed to install package '${packages}' -- ${output.error}`);
     }
   }


### PR DESCRIPTION
Previously if the process failed it would just log a generic error message without any information of why it failed to install.