### PR TITLE
OAI2-> OAI3: Fail if there is no produces provided for a path and the response has a schema/body

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,4 +72,4 @@ package-deps.json
 **/dist/*
 node_modules/*
 package-lock.json
-common/config/rush/shrinkwrap.yaml
+common/config/rush/pnpm-lock.yaml

--- a/oai2-to-oai3/changelog.md
+++ b/oai2-to-oai3/changelog.md
@@ -1,5 +1,8 @@
 # Change Log - @azure-tools/oai2-to-oai3
 
+# 4.2.0
+- **fix**: Fail if a response has no produces defined and no global defined either [PR 144](https://github.com/Azure/perks/pull/144)
+
 # 4.1.0
 - **fix**: Issue with cross-file referneces of body parameters [PR 131](https://github.com/Azure/perks/pull/131)
 

--- a/oai2-to-oai3/package.json
+++ b/oai2-to-oai3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/oai2-to-oai3",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "patchOffset": 100,
   "description": "OpenAPI2 to OpenAPI3 conversion library that maintains souremaps for use with AutoRest",
   "main": "./dist/src/index.js",

--- a/oai2-to-oai3/src/content-type-utils.ts
+++ b/oai2-to-oai3/src/content-type-utils.ts
@@ -1,4 +1,3 @@
-import { JsonPointer } from "@azure-tools/datastore";
 import { OpenAPI2Operation } from "./oai2";
 
 /**
@@ -6,10 +5,8 @@ import { OpenAPI2Operation } from "./oai2";
  * @param operationProduces: List of content type produces by the operation.
  * @param globalProduces: List of default content type produced by the API.
  * @returns list of produced content types. Array will have at least one entry.
- * @throws {Error} if no content type could be resolved.
  */
 export const resolveOperationProduces = (
-  jsonPointer: JsonPointer,
   operation: OpenAPI2Operation,
   globalProduces: string[],
 ): string[] => {
@@ -21,10 +18,8 @@ export const resolveOperationProduces = (
     : globalProduces;
 
   // default
-  if (produces.length === 0 || (produces.length === 1 && produces[0] === "*/*")) {
-    throw new Error(
-      `Operation '${operation.operationId}' (${jsonPointer}) is missing a produces field and there isn't any global value. Please add "produces": [<contentType>]"`,
-    );
+  if (produces.length === 0) {
+    produces.push("*/*");
   }
 
   return produces;
@@ -35,10 +30,7 @@ export const resolveOperationProduces = (
  * @param operationConsumes: List of content type consumed by the operation.
  * @param globalConsumes: List of default content type consumed by the API.
  */
-export const resolveOperationConsumes = (
-  operation: OpenAPI2Operation,
-  globalConsumes: string[],
-): string[] => {
+export const resolveOperationConsumes = (operation: OpenAPI2Operation, globalConsumes: string[]): string[] => {
   const operationConsumes = operation.consumes;
   return operationConsumes
     ? operationConsumes.indexOf("application/octet-stream") !== -1

--- a/oai2-to-oai3/src/content-type-utils.ts
+++ b/oai2-to-oai3/src/content-type-utils.ts
@@ -20,8 +20,6 @@ export const resolveOperationProduces = (
       : [...new Set([...operationProduces])]
     : globalProduces;
 
-  console.error("Produces", produces);
-
   // default
   if (produces.length === 0 || (produces.length === 1 && produces[0] === "*/*")) {
     throw new Error(

--- a/oai2-to-oai3/src/content-type-utils.ts
+++ b/oai2-to-oai3/src/content-type-utils.ts
@@ -1,0 +1,50 @@
+import { JsonPointer } from "@azure-tools/datastore";
+import { OpenAPI2Operation } from "./oai2";
+
+/**
+ * Resolve the list of content types produced by an operation.
+ * @param operationProduces: List of content type produces by the operation.
+ * @param globalProduces: List of default content type produced by the API.
+ * @returns list of produced content types. Array will have at least one entry.
+ * @throws {Error} if no content type could be resolved.
+ */
+export const resolveOperationProduces = (
+  jsonPointer: JsonPointer,
+  operation: OpenAPI2Operation,
+  globalProduces: string[],
+): string[] => {
+  const operationProduces = operation.produces;
+  const produces = operationProduces
+    ? operationProduces.indexOf("application/json") !== -1
+      ? operationProduces
+      : [...new Set([...operationProduces])]
+    : globalProduces;
+
+  console.error("Produces", produces);
+
+  // default
+  if (produces.length === 0 || (produces.length === 1 && produces[0] === "*/*")) {
+    throw new Error(
+      `Operation '${operation.operationId}' (${jsonPointer}) is missing a produces field and there isn't any global value. Please add "produces": [<contentType>]"`,
+    );
+  }
+
+  return produces;
+};
+
+/**
+ * Resolve the list of content types consumed by an operation.
+ * @param operationConsumes: List of content type consumed by the operation.
+ * @param globalConsumes: List of default content type consumed by the API.
+ */
+export const resolveOperationConsumes = (
+  operation: OpenAPI2Operation,
+  globalConsumes: string[],
+): string[] => {
+  const operationConsumes = operation.consumes;
+  return operationConsumes
+    ? operationConsumes.indexOf("application/octet-stream") !== -1
+      ? operationConsumes
+      : [...new Set([...operationConsumes])]
+    : globalConsumes;
+};

--- a/oai2-to-oai3/src/converter.ts
+++ b/oai2-to-oai3/src/converter.ts
@@ -1,7 +1,7 @@
 import { createGraphProxy, JsonPointer, Node, visit, get } from '@azure-tools/datastore';
 import { Mapping } from 'source-map';
 import { resolveOperationConsumes, resolveOperationProduces } from './content-type-utils';
-import { OpenAPI2Document, OpenAPI2Operation } from './oai2';
+import { OpenAPI2Document, OpenAPI2Header, OpenAPI2Operation, OpenAPI2OperationResponse } from './oai2';
 import { cleanElementName, convertOai2RefToOai3, parseOai2Ref } from './refs-utils';
 import { ResolveReferenceFn } from './runner';
 import { statusCodes } from './status-codes';
@@ -1046,7 +1046,7 @@ export class Oai2ToOai3 {
     }
   }
 
-  async visitResponse(responseTarget: any, responseValue: any, responseName: string, responsesFieldMembers: () => Iterable<Node>, jsonPointer: string, produces: Array<string>) {
+  async visitResponse(responseTarget: any, responseValue: OpenAPI2OperationResponse, responseName: string, responsesFieldMembers: () => Iterable<Node>, jsonPointer: string, produces: Array<string>) {
 
     // NOTE: The previous converter patches the description of the response because
     // every response should have a description.
@@ -1148,7 +1148,7 @@ export class Oai2ToOai3 {
     'uniqueItems'
   ];
 
-  async visitHeader(targetHeader: any, headerValue: any, jsonPointer: string) {
+  async visitHeader(targetHeader: any, headerValue: OpenAPI2Header, jsonPointer: string) {
     if (headerValue.$ref) {
       targetHeader.$ref = { value: this.convertReferenceToOai3(headerValue.schema.$ref), pointer: jsonPointer };
     } else {

--- a/oai2-to-oai3/src/converter.ts
+++ b/oai2-to-oai3/src/converter.ts
@@ -1064,7 +1064,7 @@ export class Oai2ToOai3 {
     if (responseValue.schema) {
       if (produces.length === 0 || (produces.length === 1 && produces[0] === "*/*")) {
         throw new Error(
-          `Operation response '${jsonPointer}' is missing a produces field and there isn't any global value. Please add "produces": [<contentType>]"`,
+          `Operation response '${jsonPointer}' produces type couldn't be resolved. Operation is probably is missing a produces field and there isn't any global value. Please add "produces": [<contentType>]"`,
         );
       }
 

--- a/oai2-to-oai3/src/converter.ts
+++ b/oai2-to-oai3/src/converter.ts
@@ -709,7 +709,7 @@ export class Oai2ToOai3 {
     const operation = pathItem[httpMethod];
 
     // preprocess produces and consumes for responses and parameters respectively;
-    const produces = resolveOperationProduces(jsonPointer, operationValue, globalProduces);
+    const produces = resolveOperationProduces(operationValue, globalProduces);
     const consumes = resolveOperationConsumes(operationValue, globalConsumes);
 
     for (const { value, key, pointer, children: operationFieldItemMembers } of operationItemMembers) {
@@ -1062,6 +1062,12 @@ export class Oai2ToOai3 {
     }
 
     if (responseValue.schema) {
+      if (produces.length === 0 || (produces.length === 1 && produces[0] === "*/*")) {
+        throw new Error(
+          `Operation response '${jsonPointer}' is missing a produces field and there isn't any global value. Please add "produces": [<contentType>]"`,
+        );
+      }
+
       responseTarget.content = this.newObject(jsonPointer);
       for (const mimetype of produces) {
         responseTarget.content[mimetype] = this.newObject(jsonPointer);

--- a/oai2-to-oai3/src/converter.ts
+++ b/oai2-to-oai3/src/converter.ts
@@ -1,5 +1,7 @@
 import { createGraphProxy, JsonPointer, Node, visit, get } from '@azure-tools/datastore';
 import { Mapping } from 'source-map';
+import { resolveOperationConsumes, resolveOperationProduces } from './content-type-utils';
+import { HttpMethod, HttpMethodCustom, OpenAPI2Document, OpenAPI2Operation } from './oai2';
 import { cleanElementName, convertOai2RefToOai3, parseOai2Ref } from './refs-utils';
 import { ResolveReferenceFn } from './runner';
 import { statusCodes } from './status-codes';
@@ -10,48 +12,49 @@ export class Oai2ToOai3 {
   public generated: any;
   public mappings = new Array<Mapping>();
 
-
-  constructor(protected originalFilename: string, protected original: any,  private resolveExternalReference?: ResolveReferenceFn) {
-    this.generated = createGraphProxy(this.originalFilename, '', this.mappings);
+  constructor(
+    protected originalFilename: string,
+    protected original: OpenAPI2Document,
+    private resolveExternalReference?: ResolveReferenceFn,
+  ) {
+    this.generated = createGraphProxy(this.originalFilename, "", this.mappings);
   }
 
   async convert() {
     // process servers
-    if (this.original['x-ms-parameterized-host']) {
-      const xMsPHost: any = this.original['x-ms-parameterized-host'];
+    if (this.original["x-ms-parameterized-host"]) {
+      const xMsPHost: any = this.original["x-ms-parameterized-host"];
       const server: any = {};
-      const scheme = xMsPHost.useSchemePrefix === false ? '' : ((this.original.schemes || ['http']).map(s => s + '://')[0] || '');
-      server.url = scheme + xMsPHost.hostTemplate + (this.original.basePath || '');
+      const scheme =
+        xMsPHost.useSchemePrefix === false ? "" : (this.original.schemes || ["http"]).map((s) => s + "://")[0] || "";
+      server.url = scheme + xMsPHost.hostTemplate + (this.original.basePath || "");
       if (xMsPHost.positionInOperation) {
-        server['x-ms-parameterized-host'] = { positionInOperation: xMsPHost.positionInOperation };
+        server["x-ms-parameterized-host"] = { positionInOperation: xMsPHost.positionInOperation };
       }
       server.variables = {};
       for (const msp in xMsPHost.parameters) {
-        if (!msp.startsWith('x-')) {
-
+        if (!msp.startsWith("x-")) {
           let originalParameter: any = {};
           const param: any = {};
           if (xMsPHost.parameters[msp].$ref !== undefined) {
             const parsedRef = parseOai2Ref(xMsPHost.parameters[msp].$ref);
-            
+
             if (parsedRef === undefined) {
-              throw new Error(
-                `Reference ${xMsPHost.parameters[msp].$ref} is invalid. Check the syntax.`
-              );
+              throw new Error(`Reference ${xMsPHost.parameters[msp].$ref} is invalid. Check the syntax.`);
             }
 
             originalParameter = await this.resolveReference(parsedRef.file, parsedRef.path);
-            if(originalParameter === undefined) {
-              throw new Error(
-                `Unable to resolve ${xMsPHost.parameters[msp].$ref}.`
-              );
+            if (originalParameter === undefined) {
+              throw new Error(`Unable to resolve ${xMsPHost.parameters[msp].$ref}.`);
             }
 
-            // $ref'd parameters should be client parameters 
-            if (!originalParameter['x-ms-parameter-location']) {
-              originalParameter['x-ms-parameter-location'] = 'client';
+            // $ref'd parameters should be client parameters
+            if (!originalParameter["x-ms-parameter-location"]) {
+              originalParameter["x-ms-parameter-location"] = "client";
             }
-            originalParameter['x-ms-original'] = { $ref: await this.convertReferenceToOai3(xMsPHost.parameters[msp].$ref)};
+            originalParameter["x-ms-original"] = {
+              $ref: await this.convertReferenceToOai3(xMsPHost.parameters[msp].$ref),
+            };
           } else {
             originalParameter = xMsPHost.parameters[msp];
           }
@@ -61,10 +64,10 @@ export class Oai2ToOai3 {
           // object destructuring.
           for (const key in originalParameter) {
             switch (key) {
-              case 'in':
-              case 'required':
-              case 'type':
-              case 'name':
+              case "in":
+              case "required":
+              case "type":
+              case "name":
                 // turn these into x-* properties
                 param[`x-${key}`] = originalParameter[key];
                 break;
@@ -78,9 +81,8 @@ export class Oai2ToOai3 {
           if (originalParameter.default === undefined) {
             if (originalParameter.enum) {
               param.default = originalParameter.enum[0];
-            }
-            else {
-              param.default = '';
+            } else {
+              param.default = "";
             }
           }
           // don't have empty parameters
@@ -90,15 +92,16 @@ export class Oai2ToOai3 {
         }
       }
 
-      this.generated.servers = this.newArray('/x-ms-parameterized-host');
-      this.generated.servers.__push__({ value: server, pointer: '/x-ms-parameterized-host', recurse: true });
+      this.generated.servers = this.newArray("/x-ms-parameterized-host");
+      this.generated.servers.__push__({ value: server, pointer: "/x-ms-parameterized-host", recurse: true });
     } else if (this.original.host) {
       if (this.generated.servers === undefined) {
-        this.generated.servers = this.newArray('/host');
+        this.generated.servers = this.newArray("/host");
       }
       for (const { value: s, pointer } of visit(this.original.schemes)) {
         const server: any = {};
-        server.url = (s ? s + ':' : '') + '//' + this.original.host + (this.original.basePath ? this.original.basePath : '/');
+        server.url =
+          (s ? s + ":" : "") + "//" + this.original.host + (this.original.basePath ? this.original.basePath : "/");
 
         extractServerParameters(server);
 
@@ -109,77 +112,77 @@ export class Oai2ToOai3 {
       server.url = this.original.basePath;
       extractServerParameters(server);
       if (this.generated.servers === undefined) {
-        this.generated.servers = this.newArray('/basePath');
+        this.generated.servers = this.newArray("/basePath");
       }
-      this.generated.servers.__push__({ value: server, pointer: '/basePath' });
+      this.generated.servers.__push__({ value: server, pointer: "/basePath" });
     }
 
     if (this.generated.servers === undefined) {
       // NOTE: set to empty array to match behavior from https://github.com/fearthecowboy/swagger2openapi/blob/autorest-flavor/index.js
       // In reality this should not be neccesary as severs is not required for the OAI definition to be complete.
-      this.generated.servers = this.newArray('');
+      this.generated.servers = this.newArray("");
     }
 
     // internal function to extract server parameters
     function extractServerParameters(server) {
-      server.url = server.url.split('{{').join('{');
-      server.url = server.url.split('}}').join('}');
+      server.url = server.url.split("{{").join("{");
+      server.url = server.url.split("}}").join("}");
       server.url.replace(/\{(.+?)\}/g, function (match, group1) {
         if (!server.variables) {
           server.variables = {};
         }
-        server.variables[group1] = { default: 'unknown' };
+        server.variables[group1] = { default: "unknown" };
       });
     }
 
     // extract cosumes and produces
-    const globalProduces = (this.original.produces) ? this.original.produces : ['*/*'];
-    const globalConsumes = (this.original.consumes) ? this.original.consumes : ['application/json'];
-
+    const globalProduces = this.original.produces ? this.original.produces : ["*/*"];
+    const globalConsumes = this.original.consumes ? this.original.consumes : ["application/json"];
 
     for (const { value, key, pointer, children } of visit(this.original)) {
       switch (key) {
-        case 'swagger':
-          this.generated.openapi = { value: '3.0.0', pointer };
+        case "swagger":
+          this.generated.openapi = { value: "3.0.0", pointer };
           break;
-        case 'info':
+        case "info":
           this.generated.info = this.newObject(pointer);
           await this.visitInfo(children);
           break;
-        case 'x-ms-paths':
-        case 'paths': {
-          // convert x-ms-paths to paths by just passing paths as the key.
-          const newKey = 'paths';
-          if (!this.generated[newKey]) {
-            this.generated[newKey] = this.newObject(pointer);
+        case "x-ms-paths":
+        case "paths":
+          {
+            // convert x-ms-paths to paths by just passing paths as the key.
+            const newKey = "paths";
+            if (!this.generated[newKey]) {
+              this.generated[newKey] = this.newObject(pointer);
+            }
+            await this.visitPaths(this.generated[newKey], children, globalConsumes, globalProduces);
           }
-          await this.visitPaths(this.generated[newKey], children, globalConsumes, globalProduces);
-        }
           break;
-        case 'host':
-        case 'basePath':
-        case 'schemes':
-        case 'x-ms-parameterized-host':
+        case "host":
+        case "basePath":
+        case "schemes":
+        case "x-ms-parameterized-host":
           // host, basePath and schemes already processed
           break;
-        case 'consumes':
-        case 'produces':
+        case "consumes":
+        case "produces":
           // PENDING
           break;
-        case 'definitions':
+        case "definitions":
           await this.visitDefinitions(children);
           break;
-        case 'parameters':
+        case "parameters":
           await this.visitParameterDefinitions(children);
           break;
-        case 'responses':
+        case "responses":
           if (!this.generated.components) {
             this.generated.components = this.newObject(pointer);
           }
           this.generated.components.responses = this.newObject(pointer);
           await this.visitResponsesDefinitions(children, globalProduces);
           break;
-        case 'securityDefinitions':
+        case "securityDefinitions":
           if (!this.generated.components) {
             this.generated.components = this.newObject(pointer);
           }
@@ -187,14 +190,14 @@ export class Oai2ToOai3 {
           await this.visitSecurityDefinitions(children);
           break;
         // no changes to security from OA2 to OA3
-        case 'security':
+        case "security":
           this.generated.security = { value, pointer, recurse: true };
           break;
-        case 'tags':
+        case "tags":
           this.generated.tags = this.newArray(pointer);
           await this.visitTags(children);
           break;
-        case 'externalDocs':
+        case "externalDocs":
           this.visitExternalDocs(this.generated, key, value, pointer);
           break;
         default:
@@ -208,7 +211,7 @@ export class Oai2ToOai3 {
 
   async visitParameterDefinitions(parameters: Iterable<Node>) {
     for (const { key, value, pointer, childIterator } of parameters) {
-      if (value.in !== 'formData' && value.in !== 'body' && value.type !== 'file') {
+      if (value.in !== "formData" && value.in !== "body" && value.type !== "file") {
         if (this.generated.components === undefined) {
           this.generated.components = this.newObject(pointer);
         }
@@ -221,31 +224,34 @@ export class Oai2ToOai3 {
 
         this.generated.components.parameters[cleanParamName] = this.newObject(pointer);
         await this.visitParameter(this.generated.components.parameters[cleanParamName], value, pointer, childIterator);
-      } 
+      }
     }
   }
 
-
-  async visitParameter(parameterTarget: any, parameterValue: any, pointer: string, parameterItemMembers: () => Iterable<Node>) {
+  async visitParameter(
+    parameterTarget: any,
+    parameterValue: any,
+    pointer: string,
+    parameterItemMembers: () => Iterable<Node>,
+  ) {
     if (parameterValue.$ref !== undefined) {
       parameterTarget.$ref = { value: await this.convertReferenceToOai3(parameterValue.$ref), pointer };
     } else {
-
       const parameterUnchangedProperties = [
-        'name',
-        'in',
-        'description',
-        'allowEmptyValue',
-        'required',
-        'x-ms-parameter-location',
-        'x-ms-api-version',
-        'x-comment',
-        'x-ms-parameter-grouping',
-        'x-ms-client-name',
-        'x-ms-client-default',
-        'x-ms-client-flatten',
-        'x-ms-client-request-id',
-        'x-ms-header-collection-prefix'
+        "name",
+        "in",
+        "description",
+        "allowEmptyValue",
+        "required",
+        "x-ms-parameter-location",
+        "x-ms-api-version",
+        "x-comment",
+        "x-ms-parameter-grouping",
+        "x-ms-client-name",
+        "x-ms-client-default",
+        "x-ms-client-flatten",
+        "x-ms-client-request-id",
+        "x-ms-header-collection-prefix",
       ];
 
       for (const key of parameterUnchangedProperties) {
@@ -254,41 +260,47 @@ export class Oai2ToOai3 {
         }
       }
 
-      if (parameterValue['x-ms-skip-url-encoding'] !== undefined) {
-        if (parameterValue.in === 'query') {
+      if (parameterValue["x-ms-skip-url-encoding"] !== undefined) {
+        if (parameterValue.in === "query") {
           parameterTarget.allowReserved = { value: true, pointer };
         } else {
-          parameterTarget['x-ms-skip-url-encoding'] = { value: parameterValue['x-ms-skip-url-encoding'], pointer };
+          parameterTarget["x-ms-skip-url-encoding"] = { value: parameterValue["x-ms-skip-url-encoding"], pointer };
         }
       }
 
       // Collection Format
-      if (parameterValue.type === 'array') {
-        parameterValue.collectionFormat = parameterValue.collectionFormat || 'csv';
-        if ((parameterValue.collectionFormat === 'csv') && ((parameterValue.in === 'query') || (parameterValue.in === 'cookie'))) {
-          parameterTarget.style = { value: 'form', pointer };
+      if (parameterValue.type === "array") {
+        parameterValue.collectionFormat = parameterValue.collectionFormat || "csv";
+        if (
+          parameterValue.collectionFormat === "csv" &&
+          (parameterValue.in === "query" || parameterValue.in === "cookie")
+        ) {
+          parameterTarget.style = { value: "form", pointer };
         }
-        if ((parameterValue.collectionFormat === 'csv') && ((parameterValue.in === 'path') || (parameterValue.in === 'header'))) {
-          parameterTarget.style = { value: 'simple', pointer };
+        if (
+          parameterValue.collectionFormat === "csv" &&
+          (parameterValue.in === "path" || parameterValue.in === "header")
+        ) {
+          parameterTarget.style = { value: "simple", pointer };
         }
-        if (parameterValue.collectionFormat === 'ssv') {
-          if (parameterValue.in === 'query') {
-            parameterTarget.style = { value: 'spaceDelimited', pointer };
+        if (parameterValue.collectionFormat === "ssv") {
+          if (parameterValue.in === "query") {
+            parameterTarget.style = { value: "spaceDelimited", pointer };
           }
         }
-        if (parameterValue.collectionFormat === 'pipes') {
-          if (parameterValue.in === 'query') {
-            parameterTarget.style = { value: 'pipeDelimited', pointer };
+        if (parameterValue.collectionFormat === "pipes") {
+          if (parameterValue.in === "query") {
+            parameterTarget.style = { value: "pipeDelimited", pointer };
           }
         }
-        if (parameterValue.collectionFormat === 'multi') {
-          parameterTarget.style = { value: 'form', pointer };
+        if (parameterValue.collectionFormat === "multi") {
+          parameterTarget.style = { value: "form", pointer };
           parameterTarget.explode = { value: true, pointer };
         }
 
         // tsv is no longer supported in OAI3, but we still need to support this.
-        if (parameterValue.collectionFormat === 'tsv') {
-          parameterTarget.style = { value: 'tabDelimited', pointer };
+        if (parameterValue.collectionFormat === "tsv") {
+          parameterTarget.style = { value: "tabDelimited", pointer };
         }
       }
 
@@ -297,25 +309,25 @@ export class Oai2ToOai3 {
       }
 
       const schemaKeys = [
-        'maximum',
-        'exclusiveMaximum',
-        'minimum',
-        'exclusiveMinimum',
-        'maxLength',
-        'minLength',
-        'pattern',
-        'maxItems',
-        'minItems',
-        'uniqueItems',
-        'enum',
-        'x-ms-enum',
-        'multipleOf',
-        'default',
-        'format',
+        "maximum",
+        "exclusiveMaximum",
+        "minimum",
+        "exclusiveMinimum",
+        "maxLength",
+        "minLength",
+        "pattern",
+        "maxItems",
+        "minItems",
+        "uniqueItems",
+        "enum",
+        "x-ms-enum",
+        "multipleOf",
+        "default",
+        "format",
       ];
 
       for (const { key, childIterator, pointer: jsonPointer } of parameterItemMembers()) {
-        if (key === 'schema') {
+        if (key === "schema") {
           if (parameterTarget.schema.items === undefined) {
             parameterTarget.schema.items = this.newObject(jsonPointer);
           }
@@ -325,7 +337,6 @@ export class Oai2ToOai3 {
         }
       }
 
-
       if (parameterValue.type !== undefined) {
         parameterTarget.schema.type = { value: parameterValue.type, pointer };
       }
@@ -333,7 +344,7 @@ export class Oai2ToOai3 {
       if (parameterValue.items !== undefined) {
         parameterTarget.schema.items = this.newObject(pointer);
         for (const { key, childIterator } of parameterItemMembers()) {
-          if (key === 'items') {
+          if (key === "items") {
             await this.visitSchema(parameterTarget.schema.items, parameterValue.items, childIterator);
           }
         }
@@ -344,12 +355,12 @@ export class Oai2ToOai3 {
   async visitInfo(info: Iterable<Node>) {
     for (const { value, key, pointer, children } of info) {
       switch (key) {
-        case 'title':
-        case 'description':
-        case 'termsOfService':
-        case 'contact':
-        case 'license':
-        case 'version':
+        case "title":
+        case "description":
+        case "termsOfService":
+        case "contact":
+        case "license":
+        case "version":
           this.generated.info[key] = { value, pointer };
           break;
         default:
@@ -360,17 +371,22 @@ export class Oai2ToOai3 {
   }
 
   async visitSecurityDefinitions(securityDefinitions: Iterable<Node>) {
-    for (const { key: schemeName, value: v, pointer: jsonPointer, children: securityDefinitionsItemMembers } of securityDefinitions) {
+    for (const {
+      key: schemeName,
+      value: v,
+      pointer: jsonPointer,
+      children: securityDefinitionsItemMembers,
+    } of securityDefinitions) {
       this.generated.components.securitySchemes[schemeName] = this.newObject(jsonPointer);
       const securityScheme = this.generated.components.securitySchemes[schemeName];
       switch (v.type) {
-        case 'apiKey':
+        case "apiKey":
           for (const { key, value, pointer } of securityDefinitionsItemMembers) {
             switch (key) {
-              case 'type':
-              case 'description':
-              case 'name':
-              case 'in':
+              case "type":
+              case "description":
+              case "name":
+              case "in":
                 securityScheme[key] = { value, pointer };
                 break;
               default:
@@ -379,15 +395,15 @@ export class Oai2ToOai3 {
             }
           }
           break;
-        case 'basic':
+        case "basic":
           for (const { key, value, pointer } of securityDefinitionsItemMembers) {
             switch (key) {
-              case 'description':
+              case "description":
                 securityScheme.description = { value, pointer };
                 break;
-              case 'type':
-                securityScheme.type = { value: 'http', pointer };
-                securityScheme.scheme = { value: 'basic', pointer };
+              case "type":
+                securityScheme.type = { value: "http", pointer };
+                securityScheme.scheme = { value: "basic", pointer };
                 break;
               default:
                 await this.visitExtensions(securityScheme, key, value, pointer);
@@ -395,7 +411,7 @@ export class Oai2ToOai3 {
             }
           }
           break;
-        case 'oauth2':
+        case "oauth2":
           {
             if (v.description !== undefined) {
               securityScheme.description = { value: v.description, pointer: jsonPointer };
@@ -406,12 +422,12 @@ export class Oai2ToOai3 {
             let flowName = v.flow;
 
             // convert flow names to OpenAPI 3 flow names
-            if (v.flow === 'application') {
-              flowName = 'clientCredentials';
+            if (v.flow === "application") {
+              flowName = "clientCredentials";
             }
 
-            if (v.flow === 'accessCode') {
-              flowName = 'authorizationCode';
+            if (v.flow === "accessCode") {
+              flowName = "authorizationCode";
             }
 
             securityScheme.flows[flowName] = this.newObject(jsonPointer);
@@ -419,12 +435,12 @@ export class Oai2ToOai3 {
             let tokenUrl;
 
             if (v.authorizationUrl) {
-              authorizationUrl = v.authorizationUrl.split('?')[0].trim() || '/';
+              authorizationUrl = v.authorizationUrl.split("?")[0].trim() || "/";
               securityScheme.flows[flowName].authorizationUrl = { value: authorizationUrl, pointer: jsonPointer };
             }
 
             if (v.tokenUrl) {
-              tokenUrl = v.tokenUrl.split('?')[0].trim() || '/';
+              tokenUrl = v.tokenUrl.split("?")[0].trim() || "/";
               securityScheme.flows[flowName].tokenUrl = { value: tokenUrl, pointer: jsonPointer };
             }
 
@@ -437,7 +453,12 @@ export class Oai2ToOai3 {
   }
 
   async visitDefinitions(definitions: Iterable<Node>) {
-    for (const { key: schemaName, value: schemaValue, pointer: jsonPointer, childIterator: definitionsItemMembers } of definitions) {
+    for (const {
+      key: schemaName,
+      value: schemaValue,
+      pointer: jsonPointer,
+      childIterator: definitionsItemMembers,
+    } of definitions) {
       if (this.generated.components === undefined) {
         this.generated.components = this.newObject(jsonPointer);
       }
@@ -446,7 +467,7 @@ export class Oai2ToOai3 {
         this.generated.components.schemas = this.newObject(jsonPointer);
       }
 
-      const cleanSchemaName = schemaName.replace(/\[|\]/g, '_');
+      const cleanSchemaName = schemaName.replace(/\[|\]/g, "_");
       this.generated.components.schemas[cleanSchemaName] = this.newObject(jsonPointer);
       const schemaItem = this.generated.components.schemas[cleanSchemaName];
       await this.visitSchema(schemaItem, schemaValue, definitionsItemMembers);
@@ -477,11 +498,11 @@ export class Oai2ToOai3 {
   async visitSchema(target: any, schemaValue: any, schemaItemMemebers: () => Iterable<Node>) {
     for (const { key, value, pointer, childIterator } of schemaItemMemebers()) {
       switch (key) {
-        case '$ref':
+        case "$ref":
           target.$ref = { value: await this.convertReferenceToOai3(value), pointer };
           break;
-        case 'additionalProperties':
-          if (typeof (value) === 'boolean') {
+        case "additionalProperties":
+          if (typeof value === "boolean") {
             if (value === true) {
               target[key] = { value, pointer };
             } // false is assumed anyway in autorest.
@@ -490,66 +511,66 @@ export class Oai2ToOai3 {
             await this.visitSchema(target[key], value, childIterator);
           }
           break;
-        case 'required':
-        case 'title':
-        case 'description':
-        case 'default':
-        case 'multipleOf':
-        case 'maximum':
-        case 'exclusiveMaximum':
-        case 'minimum':
-        case 'exclusiveMinimum':
-        case 'maxLength':
-        case 'minLength':
-        case 'pattern':
-        case 'maxItems':
-        case 'minItems':
-        case 'uniqueItems':
-        case 'maxProperties':
-        case 'minProperties':
-        case 'enum':
-        case 'readOnly':
+        case "required":
+        case "title":
+        case "description":
+        case "default":
+        case "multipleOf":
+        case "maximum":
+        case "exclusiveMaximum":
+        case "minimum":
+        case "exclusiveMinimum":
+        case "maxLength":
+        case "minLength":
+        case "pattern":
+        case "maxItems":
+        case "minItems":
+        case "uniqueItems":
+        case "maxProperties":
+        case "minProperties":
+        case "enum":
+        case "readOnly":
           target[key] = { value, pointer, recurse: true };
           break;
-        case 'allOf':
+        case "allOf":
           target.allOf = this.newArray(pointer);
           await this.visitAllOf(target.allOf, childIterator);
           break;
-        case 'items':
+        case "items":
           target[key] = this.newObject(pointer);
           await this.visitSchema(target[key], value, childIterator);
           break;
-        case 'properties':
+        case "properties":
           target[key] = this.newObject(pointer);
           await this.visitProperties(target[key], childIterator);
           break;
-        case 'type':
-        case 'format':
+        case "type":
+        case "format":
           target[key] = { value, pointer };
           break;
         // in OpenAPI 3 the discriminator its an object instead of a string.
-        case 'discriminator':
+        case "discriminator":
           target.discriminator = this.newObject(pointer);
           target.discriminator.propertyName = { value, pointer };
           break;
-        case 'xml':
+        case "xml":
           this.visitXml(target, key, value, pointer);
           break;
-        case 'externalDocs':
+        case "externalDocs":
           this.visitExternalDocs(target, key, value, pointer);
           break;
-        case 'example':
+        case "example":
           target.example = { value, pointer, recurse: true };
           break;
-        case 'x-nullable':
-          target['nullable'] = { value, pointer };
+        case "x-nullable":
+          target["nullable"] = { value, pointer };
 
           // NOTE: this matches the previous converter behavior ... when a $ref
           // is inside the schema copy the properties as they are don't update
           // names, but also leave the new `nullable` field so that OpenAPI 3
           // readers pick it up correctly.
           if (schemaValue.$ref !== undefined) {
-            target['x-nullable'] = { value, pointer };
+            target["x-nullable"] = { value, pointer };
           }
           break;
         default:
@@ -597,11 +618,11 @@ export class Oai2ToOai3 {
 
     for (const { key, pointer, value } of tagItemMembers) {
       switch (key) {
-        case 'name':
-        case 'description':
+        case "name":
+        case "description":
           this.generated.tags[index][key] = { value, pointer };
           break;
-        case 'externalDocs':
+        case "externalDocs":
           this.visitExternalDocs(this.generated.tags[index], key, value, pointer);
           break;
         default:
@@ -616,7 +637,7 @@ export class Oai2ToOai3 {
   }
 
   private async resolveReference(file: string, path: string): Promise<any | undefined> {
-    if(file === "" || file === this.originalFilename) {
+    if (file === "" || file === this.originalFilename) {
       return get(this.original, path);
     } else {
       if (this.resolveExternalReference) {
@@ -628,7 +649,7 @@ export class Oai2ToOai3 {
 
   async visitExtensions(target: any, key: string, value: any, pointer: string) {
     switch (key) {
-      case 'x-ms-odata':
+      case "x-ms-odata":
         target[key] = { value: await this.convertReferenceToOai3(value), pointer };
         break;
       default:
@@ -661,28 +682,43 @@ export class Oai2ToOai3 {
     }
   }
 
-  async visitPath(target: any, uri: string, jsonPointer: JsonPointer, pathItemMembers: Iterable<Node>, globalConsumes: Array<string>, globalProduces: Array<string>) {
+  async visitPath(
+    target: any,
+    uri: string,
+    jsonPointer: JsonPointer,
+    pathItemMembers: Iterable<Node>,
+    globalConsumes: Array<string>,
+    globalProduces: Array<string>,
+  ) {
     target[uri] = this.newObject(jsonPointer);
     const pathItem = target[uri];
     for (const { value, key, pointer, children: pathItemFieldMembers } of pathItemMembers) {
       // handle each item in the path object
       switch (key) {
-        case '$ref':
-        case 'x-summary':
-        case 'x-description':
+        case "$ref":
+        case "x-summary":
+        case "x-description":
           pathItem[key] = { value, pointer };
           break;
-        case 'get':
-        case 'put':
-        case 'post':
-        case 'delete':
-        case 'options':
-        case 'head':
-        case 'patch':
-        case 'x-trace':
-          await this.visitOperation(pathItem, key, pointer, pathItemFieldMembers, value, globalConsumes, globalProduces);
+        case "get":
+        case "put":
+        case "post":
+        case "delete":
+        case "options":
+        case "head":
+        case "patch":
+        case "x-trace":
+          await this.visitOperation(
+            pathItem,
+            key,
+            pointer,
+            pathItemFieldMembers,
+            value,
+            globalConsumes,
+            globalProduces,
+          );
           break;
-        case 'parameters':
+        case "parameters":
           pathItem.parameters = this.newArray(pointer);
           await this.visitPathParameters(pathItem.parameters, pathItemFieldMembers);
           break;
@@ -697,58 +733,54 @@ export class Oai2ToOai3 {
     }
   }
 
-  async visitOperation(pathItem: any, httpMethod: string, jsonPointer: JsonPointer, operationItemMembers: Iterable<Node>, operationValue: any, globalConsumes: Array<string>, globalProduces: Array<string>) {
-
+  async visitOperation(
+    pathItem: any,
+    httpMethod: HttpMethod | HttpMethodCustom,
+    jsonPointer: JsonPointer,
+    operationItemMembers: Iterable<Node>,
+    operationValue: OpenAPI2Operation,
+    globalConsumes: Array<string>,
+    globalProduces: Array<string>,
+  ) {
     // trace was not supported on OpenAPI 2.0, it was an extension
-    httpMethod = (httpMethod !== 'x-trace') ? httpMethod : 'trace';
+    httpMethod = httpMethod !== "x-trace" ? httpMethod : "trace";
     pathItem[httpMethod] = this.newObject(jsonPointer);
 
     // handle a single operation.
     const operation = pathItem[httpMethod];
 
     // preprocess produces and consumes for responses and parameters respectively;
-    const produces = (operationValue.produces) ?
-      (operationValue.produces.indexOf('application/json') !== -1) ?
-        operationValue.produces :
-        [...new Set([...operationValue.produces])] :
-      globalProduces;
+    const produces = resolveOperationProduces(jsonPointer, operationValue, globalProduces);
+    const consumes = resolveOperationConsumes(operationValue, globalProduces);
 
-    // default
-    if (produces.length === 0) {
-      produces.push('*/*');
-    }
-
-    const consumes = (operationValue.consumes) ? (operationValue.consumes.indexOf('application/octet-stream') !== -1) ? operationValue.consumes
-      : [...new Set([...operationValue.consumes])]
-      : globalConsumes;
     for (const { value, key, pointer, children: operationFieldItemMembers } of operationItemMembers) {
       switch (key) {
-        case 'tags':
-        case 'description':
-        case 'summary':
-        case 'operationId':
-        case 'deprecated':
+        case "tags":
+        case "description":
+        case "summary":
+        case "operationId":
+        case "deprecated":
           operation[key] = { value, pointer };
           break;
-        case 'externalDocs':
+        case "externalDocs":
           this.visitExternalDocs(operation, key, value, pointer);
           break;
-        case 'consumes':
+        case "consumes":
           // handled beforehand for parameters
           break;
-        case 'parameters':
+        case "parameters":
           await this.visitParameters(operation, operationFieldItemMembers, consumes, pointer);
           break;
-        case 'produces':
+        case "produces":
           // handled beforehand for responses
           break;
-        case 'responses':
+        case "responses":
           operation.responses = this.newObject(pointer);
           await this.visitResponses(operation.responses, operationFieldItemMembers, produces);
           break;
-        case 'schemes':
+        case "schemes":
           break;
-        case 'security':
+        case "security":
           operation.security = { value, pointer, recurse: true };
           break;
         default:
@@ -759,17 +791,24 @@ export class Oai2ToOai3 {
   }
 
   async visitParameters(targetOperation: any, parametersFieldItemMembers: any, consumes: any, pointer: string) {
-    const requestBodyTracker = { xmsname: undefined, name: undefined, description: undefined, index: -1, keepTrackingIndex: true, wasSpecialParameterFound: false, wasParamRequired: false };
+    const requestBodyTracker = {
+      xmsname: undefined,
+      name: undefined,
+      description: undefined,
+      index: -1,
+      keepTrackingIndex: true,
+      wasSpecialParameterFound: false,
+      wasParamRequired: false,
+    };
 
-    
     for (let { pointer, value, childIterator } of parametersFieldItemMembers) {
       if (value.$ref) {
         const parsedRef = parseOai2Ref(value.$ref);
-        if(parsedRef === undefined) {
+        if (parsedRef === undefined) {
           throw new Error(`Reference ${value.$ref} is not a valid ref(at ${pointer})`);
         }
         const parameterName = parsedRef.componentName;
-        if(parsedRef.basePath === "/parameters/") {
+        if (parsedRef.basePath === "/parameters/") {
           // TODO: I think we don't need this at all and can just call the else. TO check when adding the unit tests.
           if (parsedRef.file == "" || parsedRef.file === this.originalFilename) {
             const dereferencedParameter = get(this.original, parsedRef.path);
@@ -805,26 +844,26 @@ export class Oai2ToOai3 {
         }
       }
 
-      if (value.in === 'body' || value.type === 'file' || value.in === 'formData') {
+      if (value.in === "body" || value.type === "file" || value.in === "formData") {
         if (!requestBodyTracker.wasSpecialParameterFound && value.description !== undefined) {
           requestBodyTracker.description = value.description;
         } else {
           requestBodyTracker.description = undefined;
         }
 
-        if (value['x-ms-client-name']) {
-          requestBodyTracker.xmsname = value['x-ms-client-name'];
+        if (value["x-ms-client-name"]) {
+          requestBodyTracker.xmsname = value["x-ms-client-name"];
         } else if (value.name) {
           requestBodyTracker.name = value.name;
         }
 
-        if ((value.in === 'body' || value.type === 'file') && value.in !== 'formData') {
+        if ((value.in === "body" || value.type === "file") && value.in !== "formData") {
           requestBodyTracker.wasParamRequired = value.required;
         }
       }
 
       if (requestBodyTracker.keepTrackingIndex) {
-        if (!(value.in === 'body' || value.type === 'file' || value.in === 'formData')) {
+        if (!(value.in === "body" || value.type === "file" || value.in === "formData")) {
           if (requestBodyTracker.wasSpecialParameterFound) {
             requestBodyTracker.keepTrackingIndex = false;
           }
@@ -841,8 +880,6 @@ export class Oai2ToOai3 {
     }
 
     if (targetOperation.requestBody !== undefined) {
-
-
       if (requestBodyTracker.wasParamRequired) {
         targetOperation.requestBody.required = { value: requestBodyTracker.wasParamRequired, pointer };
       }
@@ -852,27 +889,31 @@ export class Oai2ToOai3 {
       }
 
       if (requestBodyTracker.xmsname) {
-        if (targetOperation.requestBody['x-ms-client-name'] === undefined) {
-          targetOperation.requestBody['x-ms-client-name'] = { value: requestBodyTracker.xmsname, pointer };
+        if (targetOperation.requestBody["x-ms-client-name"] === undefined) {
+          targetOperation.requestBody["x-ms-client-name"] = { value: requestBodyTracker.xmsname, pointer };
         }
 
-        targetOperation.requestBody['x-ms-requestBody-name'] = { value: requestBodyTracker.xmsname, pointer };
+        targetOperation.requestBody["x-ms-requestBody-name"] = { value: requestBodyTracker.xmsname, pointer };
       } else if (requestBodyTracker.name) {
-        targetOperation.requestBody['x-ms-requestBody-name'] = { value: requestBodyTracker.name, pointer };
+        targetOperation.requestBody["x-ms-requestBody-name"] = { value: requestBodyTracker.name, pointer };
       }
 
       if (targetOperation.parameters === undefined) {
-        targetOperation['x-ms-requestBody-index'] = { value: 0, pointer };
-
+        targetOperation["x-ms-requestBody-index"] = { value: 0, pointer };
       } else {
-        targetOperation['x-ms-requestBody-index'] = { value: requestBodyTracker.index, pointer };
+        targetOperation["x-ms-requestBody-index"] = { value: requestBodyTracker.index, pointer };
       }
     }
   }
 
-  async visitOperationParameter(targetOperation: any, parameterValue: any, pointer: string, parameterItemMembers: () => Iterable<Node>, consumes: Array<any>) {
-    if (parameterValue.in === 'formData' || parameterValue.in === 'body' || parameterValue.type === 'file') {
-
+  async visitOperationParameter(
+    targetOperation: any,
+    parameterValue: any,
+    pointer: string,
+    parameterItemMembers: () => Iterable<Node>,
+    consumes: Array<any>,
+  ) {
+    if (parameterValue.in === "formData" || parameterValue.in === "body" || parameterValue.type === "file") {
       if (targetOperation.requestBody === undefined) {
         targetOperation.requestBody = this.newObject(pointer);
       }
@@ -881,27 +922,35 @@ export class Oai2ToOai3 {
         targetOperation.requestBody.content = this.newObject(pointer);
       }
 
-      if (parameterValue['x-ms-parameter-location'] && targetOperation.requestBody['x-ms-parameter-location'] === undefined) {
-        targetOperation.requestBody['x-ms-parameter-location'] = { value: parameterValue['x-ms-parameter-location'], pointer };
+      if (
+        parameterValue["x-ms-parameter-location"] &&
+        targetOperation.requestBody["x-ms-parameter-location"] === undefined
+      ) {
+        targetOperation.requestBody["x-ms-parameter-location"] = {
+          value: parameterValue["x-ms-parameter-location"],
+          pointer,
+        };
       }
 
-      if (parameterValue['x-ms-client-flatten'] !== undefined && targetOperation.requestBody['x-ms-client-flatten'] === undefined) {
-        targetOperation.requestBody['x-ms-client-flatten'] = { value: parameterValue['x-ms-client-flatten'], pointer };
+      if (
+        parameterValue["x-ms-client-flatten"] !== undefined &&
+        targetOperation.requestBody["x-ms-client-flatten"] === undefined
+      ) {
+        targetOperation.requestBody["x-ms-client-flatten"] = { value: parameterValue["x-ms-client-flatten"], pointer };
       }
 
-      if (parameterValue['x-ms-enum'] !== undefined && targetOperation.requestBody['x-ms-enum'] === undefined) {
-        targetOperation.requestBody['x-ms-enum'] = { value: parameterValue['x-ms-enum'], pointer };
+      if (parameterValue["x-ms-enum"] !== undefined && targetOperation.requestBody["x-ms-enum"] === undefined) {
+        targetOperation.requestBody["x-ms-enum"] = { value: parameterValue["x-ms-enum"], pointer };
       }
 
       if (parameterValue.allowEmptyValue !== undefined && targetOperation.requestBody.allowEmptyValue === undefined) {
         targetOperation.requestBody.allowEmptyValue = { value: parameterValue.allowEmptyValue, pointer };
       }
 
-      if (parameterValue.in === 'formData') {
-
-        let contentType = 'application/x-www-form-urlencoded';
-        if ((consumes.length) && (consumes.indexOf('multipart/form-data') >= 0)) {
-          contentType = 'multipart/form-data';
+      if (parameterValue.in === "formData") {
+        let contentType = "application/x-www-form-urlencoded";
+        if (consumes.length && consumes.indexOf("multipart/form-data") >= 0) {
+          contentType = "multipart/form-data";
         }
 
         if (targetOperation.requestBody.content[contentType] === undefined) {
@@ -914,14 +963,14 @@ export class Oai2ToOai3 {
 
         if (parameterValue.schema !== undefined) {
           for (const { key, value, childIterator } of parameterItemMembers()) {
-            if (key === 'schema') {
+            if (key === "schema") {
               await this.visitSchema(targetOperation.requestBody.content[contentType].schema, value, childIterator);
             }
           }
         } else {
           const schema = targetOperation.requestBody.content[contentType].schema;
           if (schema.type === undefined) {
-            schema.type = { value: 'object', pointer };
+            schema.type = { value: "object", pointer };
           }
 
           if (schema.properties === undefined) {
@@ -940,9 +989,9 @@ export class Oai2ToOai3 {
 
           if (parameterValue.type !== undefined) {
             // OpenAPI 3 wants to see `type: file` as `type:string` with `format: binary`
-            if (parameterValue.type === 'file') {
-              targetProperty.type = { value: 'string', pointer };
-              targetProperty.format = { value: 'binary', pointer };
+            if (parameterValue.type === "file") {
+              targetProperty.type = { value: "string", pointer };
+              targetProperty.format = { value: "binary", pointer };
             } else {
               targetProperty.type = { value: parameterValue.type, pointer };
             }
@@ -968,12 +1017,12 @@ export class Oai2ToOai3 {
             targetProperty.allOf = { value: parameterValue.allOf, pointer };
           }
 
-          if (parameterValue.type === 'array' && parameterValue.items !== undefined) {
+          if (parameterValue.type === "array" && parameterValue.items !== undefined) {
             // Support the case where an operation can accept multiple files
-            if (contentType === 'multipart/form-data' && parameterValue.items.type === 'file') {
+            if (contentType === "multipart/form-data" && parameterValue.items.type === "file") {
               targetProperty.items = this.newObject(pointer);
-              targetProperty.items.type = { value: 'string', pointer: `${pointer}/items` };
-              targetProperty.items.format = { value: 'binary', pointer: `${pointer}/items` };
+              targetProperty.items.type = { value: "string", pointer: `${pointer}/items` };
+              targetProperty.items.format = { value: "binary", pointer: `${pointer}/items` };
             } else {
               targetProperty.items = { value: parameterValue.items, pointer };
             }
@@ -981,24 +1030,22 @@ export class Oai2ToOai3 {
 
           // copy extensions in target property
           for (const { key, pointer: fieldPointer, value } of parameterItemMembers()) {
-            if (key.startsWith('x-')) {
+            if (key.startsWith("x-")) {
               targetProperty[key] = { value: value, pointer: fieldPointer };
             }
           }
         }
-      } else if (parameterValue.type === 'file') {
-
-        targetOperation['application/octet-stream'] = this.newObject(pointer);
-        targetOperation['application/octet-stream'].schema = this.newObject(pointer);
-        targetOperation['application/octet-stream'].schema.type = { value: 'string', pointer };
-        targetOperation['application/octet-stream'].schema.format = { value: 'binary', pointer };
+      } else if (parameterValue.type === "file") {
+        targetOperation["application/octet-stream"] = this.newObject(pointer);
+        targetOperation["application/octet-stream"].schema = this.newObject(pointer);
+        targetOperation["application/octet-stream"].schema.type = { value: "string", pointer };
+        targetOperation["application/octet-stream"].schema.format = { value: "binary", pointer };
       }
 
-      if (parameterValue.in === 'body') {
-
+      if (parameterValue.in === "body") {
         const consumesTempArray = [...consumes];
         if (consumesTempArray.length === 0) {
-          consumesTempArray.push('application/json');
+          consumesTempArray.push("application/json");
         }
 
         for (const mimetype of consumesTempArray) {
@@ -1012,19 +1059,18 @@ export class Oai2ToOai3 {
 
           if (parameterValue.schema !== undefined) {
             for (const { key, value, childIterator } of parameterItemMembers()) {
-              if (key === 'schema') {
+              if (key === "schema") {
                 await this.visitSchema(targetOperation.requestBody.content[mimetype].schema, value, childIterator);
               }
             }
           } else {
             targetOperation.requestBody.content[mimetype].schema = this.newObject(pointer);
           }
-
         }
 
         // copy extensions in requestBody
         for (const { key, pointer: fieldPointer, value } of parameterItemMembers()) {
-          if (key.startsWith('x-')) {
+          if (key.startsWith("x-")) {
             if (!targetOperation.requestBody[key]) {
               targetOperation.requestBody[key] = { value: value, pointer: fieldPointer };
             }
@@ -1047,7 +1093,7 @@ export class Oai2ToOai3 {
       target[key] = this.newObject(pointer);
       if (value.$ref) {
         target[key].$ref = { value: await this.convertReferenceToOai3(value.$ref), pointer };
-      } else if (key.startsWith('x-')) {
+      } else if (key.startsWith("x-")) {
         await this.visitExtensions(target[key], key, value, pointer);
       } else {
         await this.visitResponse(target[key], value, key, childIterator, pointer, produces);
@@ -1055,17 +1101,23 @@ export class Oai2ToOai3 {
     }
   }
 
-  async visitResponse(responseTarget: any, responseValue: any, responseName: string, responsesFieldMembers: () => Iterable<Node>, jsonPointer: string, produces: Array<string>) {
-
+  async visitResponse(
+    responseTarget: any,
+    responseValue: any,
+    responseName: string,
+    responsesFieldMembers: () => Iterable<Node>,
+    jsonPointer: string,
+    produces: Array<string>,
+  ) {
     // NOTE: The previous converter patches the description of the response because
     // every response should have a description.
     // So, to match previous behavior we do too.
-    if (responseValue.description === undefined || responseValue.description === '') {
+    if (responseValue.description === undefined || responseValue.description === "") {
       const sc = statusCodes.find((e) => {
         return e.code === responseName;
       });
 
-      responseTarget.description = { value: (sc ? sc.phrase : ''), pointer: jsonPointer };
+      responseTarget.description = { value: sc ? sc.phrase : "", pointer: jsonPointer };
     } else {
       responseTarget.description = { value: responseValue.description, pointer: jsonPointer };
     }
@@ -1076,7 +1128,7 @@ export class Oai2ToOai3 {
         responseTarget.content[mimetype] = this.newObject(jsonPointer);
         responseTarget.content[mimetype].schema = this.newObject(jsonPointer);
         for (const { key, value, childIterator } of responsesFieldMembers()) {
-          if (key === 'schema') {
+          if (key === "schema") {
             await this.visitSchema(responseTarget.content[mimetype].schema, value, childIterator);
           }
         }
@@ -1102,7 +1154,10 @@ export class Oai2ToOai3 {
       if (responseTarget.content[mimetype].examples === undefined) {
         responseTarget.content[mimetype].examples = this.newObject(jsonPointer);
         responseTarget.content[mimetype].examples.response = this.newObject(jsonPointer);
-        responseTarget.content[mimetype].examples.response.value = { value: responseValue.examples[mimetype], pointer: jsonPointer };
+        responseTarget.content[mimetype].examples.response.value = {
+          value: responseValue.examples[mimetype],
+          pointer: jsonPointer,
+        };
       }
     }
 
@@ -1114,42 +1169,36 @@ export class Oai2ToOai3 {
       }
     }
 
-    // copy extensions 
+    // copy extensions
     for (const { key, pointer: fieldPointer, value } of responsesFieldMembers()) {
-      if (key.startsWith('x-') && responseTarget[key] === undefined) {
+      if (key.startsWith("x-") && responseTarget[key] === undefined) {
         responseTarget[key] = { value: value, pointer: fieldPointer };
       }
     }
   }
 
-
   parameterTypeProperties = [
-    'format',
-    'minimum',
-    'maximum',
-    'exclusiveMinimum',
-    'exclusiveMaximum',
-    'minLength',
-    'maxLength',
-    'multipleOf',
-    'minItems',
-    'maxItems',
-    'uniqueItems',
-    'minProperties',
-    'maxProperties',
-    'additionalProperties',
-    'pattern',
-    'enum',
-    'x-ms-enum',
-    'default'
+    "format",
+    "minimum",
+    "maximum",
+    "exclusiveMinimum",
+    "exclusiveMaximum",
+    "minLength",
+    "maxLength",
+    "multipleOf",
+    "minItems",
+    "maxItems",
+    "uniqueItems",
+    "minProperties",
+    "maxProperties",
+    "additionalProperties",
+    "pattern",
+    "enum",
+    "x-ms-enum",
+    "default",
   ];
 
-  arrayProperties = [
-    'items',
-    'minItems',
-    'maxItems',
-    'uniqueItems'
-  ];
+  arrayProperties = ["items", "minItems", "maxItems", "uniqueItems"];
 
   async visitHeader(targetHeader: any, headerValue: any, jsonPointer: string) {
     if (headerValue.$ref) {
@@ -1164,11 +1213,11 @@ export class Oai2ToOai3 {
       }
 
       for (const { key, childIterator } of visit(headerValue)) {
-        if (key === 'schema') {
+        if (key === "schema") {
           await this.visitSchema(targetHeader.schema.items, headerValue.items, childIterator);
         } else if (this.parameterTypeProperties.includes(key) || this.arrayProperties.includes(key)) {
           targetHeader.schema[key] = { value: headerValue[key], pointer: jsonPointer, recurse: true };
-        } else if (key.startsWith('x-') && targetHeader[key] === undefined) {
+        } else if (key.startsWith("x-") && targetHeader[key] === undefined) {
           targetHeader[key] = { value: headerValue[key], pointer: jsonPointer, recurse: true };
         }
       }
@@ -1177,11 +1226,11 @@ export class Oai2ToOai3 {
         targetHeader.schema.type = { value: headerValue.type, pointer: jsonPointer };
       }
       if (headerValue.items && headerValue.items.collectionFormat) {
-        if (headerValue.collectionFormat === 'csv') {
-          targetHeader.style = { value: 'simple', pointer: jsonPointer };
+        if (headerValue.collectionFormat === "csv") {
+          targetHeader.style = { value: "simple", pointer: jsonPointer };
         }
 
-        if (headerValue.collectionFormat === 'multi') {
+        if (headerValue.collectionFormat === "multi") {
           targetHeader.explode = { value: true, pointer: jsonPointer };
         }
       }

--- a/oai2-to-oai3/src/converter.ts
+++ b/oai2-to-oai3/src/converter.ts
@@ -1,7 +1,7 @@
 import { createGraphProxy, JsonPointer, Node, visit, get } from '@azure-tools/datastore';
 import { Mapping } from 'source-map';
 import { resolveOperationConsumes, resolveOperationProduces } from './content-type-utils';
-import { HttpMethod, HttpMethodCustom, OpenAPI2Document, OpenAPI2Operation } from './oai2';
+import { OpenAPI2Document, OpenAPI2Operation } from './oai2';
 import { cleanElementName, convertOai2RefToOai3, parseOai2Ref } from './refs-utils';
 import { ResolveReferenceFn } from './runner';
 import { statusCodes } from './status-codes';
@@ -12,49 +12,48 @@ export class Oai2ToOai3 {
   public generated: any;
   public mappings = new Array<Mapping>();
 
-  constructor(
-    protected originalFilename: string,
-    protected original: OpenAPI2Document,
-    private resolveExternalReference?: ResolveReferenceFn,
-  ) {
-    this.generated = createGraphProxy(this.originalFilename, "", this.mappings);
+
+  constructor(protected originalFilename: string, protected original: OpenAPI2Document,  private resolveExternalReference?: ResolveReferenceFn) {
+    this.generated = createGraphProxy(this.originalFilename, '', this.mappings);
   }
 
   async convert() {
     // process servers
-    if (this.original["x-ms-parameterized-host"]) {
-      const xMsPHost: any = this.original["x-ms-parameterized-host"];
+    if (this.original['x-ms-parameterized-host']) {
+      const xMsPHost: any = this.original['x-ms-parameterized-host'];
       const server: any = {};
-      const scheme =
-        xMsPHost.useSchemePrefix === false ? "" : (this.original.schemes || ["http"]).map((s) => s + "://")[0] || "";
-      server.url = scheme + xMsPHost.hostTemplate + (this.original.basePath || "");
+      const scheme = xMsPHost.useSchemePrefix === false ? '' : ((this.original.schemes || ['http']).map(s => s + '://')[0] || '');
+      server.url = scheme + xMsPHost.hostTemplate + (this.original.basePath || '');
       if (xMsPHost.positionInOperation) {
-        server["x-ms-parameterized-host"] = { positionInOperation: xMsPHost.positionInOperation };
+        server['x-ms-parameterized-host'] = { positionInOperation: xMsPHost.positionInOperation };
       }
       server.variables = {};
       for (const msp in xMsPHost.parameters) {
-        if (!msp.startsWith("x-")) {
+        if (!msp.startsWith('x-')) {
+
           let originalParameter: any = {};
           const param: any = {};
           if (xMsPHost.parameters[msp].$ref !== undefined) {
             const parsedRef = parseOai2Ref(xMsPHost.parameters[msp].$ref);
-
+            
             if (parsedRef === undefined) {
-              throw new Error(`Reference ${xMsPHost.parameters[msp].$ref} is invalid. Check the syntax.`);
+              throw new Error(
+                `Reference ${xMsPHost.parameters[msp].$ref} is invalid. Check the syntax.`
+              );
             }
 
             originalParameter = await this.resolveReference(parsedRef.file, parsedRef.path);
-            if (originalParameter === undefined) {
-              throw new Error(`Unable to resolve ${xMsPHost.parameters[msp].$ref}.`);
+            if(originalParameter === undefined) {
+              throw new Error(
+                `Unable to resolve ${xMsPHost.parameters[msp].$ref}.`
+              );
             }
 
-            // $ref'd parameters should be client parameters
-            if (!originalParameter["x-ms-parameter-location"]) {
-              originalParameter["x-ms-parameter-location"] = "client";
+            // $ref'd parameters should be client parameters 
+            if (!originalParameter['x-ms-parameter-location']) {
+              originalParameter['x-ms-parameter-location'] = 'client';
             }
-            originalParameter["x-ms-original"] = {
-              $ref: await this.convertReferenceToOai3(xMsPHost.parameters[msp].$ref),
-            };
+            originalParameter['x-ms-original'] = { $ref: await this.convertReferenceToOai3(xMsPHost.parameters[msp].$ref)};
           } else {
             originalParameter = xMsPHost.parameters[msp];
           }
@@ -64,10 +63,10 @@ export class Oai2ToOai3 {
           // object destructuring.
           for (const key in originalParameter) {
             switch (key) {
-              case "in":
-              case "required":
-              case "type":
-              case "name":
+              case 'in':
+              case 'required':
+              case 'type':
+              case 'name':
                 // turn these into x-* properties
                 param[`x-${key}`] = originalParameter[key];
                 break;
@@ -81,8 +80,9 @@ export class Oai2ToOai3 {
           if (originalParameter.default === undefined) {
             if (originalParameter.enum) {
               param.default = originalParameter.enum[0];
-            } else {
-              param.default = "";
+            }
+            else {
+              param.default = '';
             }
           }
           // don't have empty parameters
@@ -92,16 +92,15 @@ export class Oai2ToOai3 {
         }
       }
 
-      this.generated.servers = this.newArray("/x-ms-parameterized-host");
-      this.generated.servers.__push__({ value: server, pointer: "/x-ms-parameterized-host", recurse: true });
+      this.generated.servers = this.newArray('/x-ms-parameterized-host');
+      this.generated.servers.__push__({ value: server, pointer: '/x-ms-parameterized-host', recurse: true });
     } else if (this.original.host) {
       if (this.generated.servers === undefined) {
-        this.generated.servers = this.newArray("/host");
+        this.generated.servers = this.newArray('/host');
       }
       for (const { value: s, pointer } of visit(this.original.schemes)) {
         const server: any = {};
-        server.url =
-          (s ? s + ":" : "") + "//" + this.original.host + (this.original.basePath ? this.original.basePath : "/");
+        server.url = (s ? s + ':' : '') + '//' + this.original.host + (this.original.basePath ? this.original.basePath : '/');
 
         extractServerParameters(server);
 
@@ -112,77 +111,77 @@ export class Oai2ToOai3 {
       server.url = this.original.basePath;
       extractServerParameters(server);
       if (this.generated.servers === undefined) {
-        this.generated.servers = this.newArray("/basePath");
+        this.generated.servers = this.newArray('/basePath');
       }
-      this.generated.servers.__push__({ value: server, pointer: "/basePath" });
+      this.generated.servers.__push__({ value: server, pointer: '/basePath' });
     }
 
     if (this.generated.servers === undefined) {
       // NOTE: set to empty array to match behavior from https://github.com/fearthecowboy/swagger2openapi/blob/autorest-flavor/index.js
       // In reality this should not be neccesary as severs is not required for the OAI definition to be complete.
-      this.generated.servers = this.newArray("");
+      this.generated.servers = this.newArray('');
     }
 
     // internal function to extract server parameters
     function extractServerParameters(server) {
-      server.url = server.url.split("{{").join("{");
-      server.url = server.url.split("}}").join("}");
+      server.url = server.url.split('{{').join('{');
+      server.url = server.url.split('}}').join('}');
       server.url.replace(/\{(.+?)\}/g, function (match, group1) {
         if (!server.variables) {
           server.variables = {};
         }
-        server.variables[group1] = { default: "unknown" };
+        server.variables[group1] = { default: 'unknown' };
       });
     }
 
     // extract cosumes and produces
-    const globalProduces = this.original.produces ? this.original.produces : ["*/*"];
-    const globalConsumes = this.original.consumes ? this.original.consumes : ["application/json"];
+    const globalProduces = (this.original.produces) ? this.original.produces : ['*/*'];
+    const globalConsumes = (this.original.consumes) ? this.original.consumes : ['application/json'];
+
 
     for (const { value, key, pointer, children } of visit(this.original)) {
       switch (key) {
-        case "swagger":
-          this.generated.openapi = { value: "3.0.0", pointer };
+        case 'swagger':
+          this.generated.openapi = { value: '3.0.0', pointer };
           break;
-        case "info":
+        case 'info':
           this.generated.info = this.newObject(pointer);
           await this.visitInfo(children);
           break;
-        case "x-ms-paths":
-        case "paths":
-          {
-            // convert x-ms-paths to paths by just passing paths as the key.
-            const newKey = "paths";
-            if (!this.generated[newKey]) {
-              this.generated[newKey] = this.newObject(pointer);
-            }
-            await this.visitPaths(this.generated[newKey], children, globalConsumes, globalProduces);
+        case 'x-ms-paths':
+        case 'paths': {
+          // convert x-ms-paths to paths by just passing paths as the key.
+          const newKey = 'paths';
+          if (!this.generated[newKey]) {
+            this.generated[newKey] = this.newObject(pointer);
           }
+          await this.visitPaths(this.generated[newKey], children, globalConsumes, globalProduces);
+        }
           break;
-        case "host":
-        case "basePath":
-        case "schemes":
-        case "x-ms-parameterized-host":
+        case 'host':
+        case 'basePath':
+        case 'schemes':
+        case 'x-ms-parameterized-host':
           // host, basePath and schemes already processed
           break;
-        case "consumes":
-        case "produces":
+        case 'consumes':
+        case 'produces':
           // PENDING
           break;
-        case "definitions":
+        case 'definitions':
           await this.visitDefinitions(children);
           break;
-        case "parameters":
+        case 'parameters':
           await this.visitParameterDefinitions(children);
           break;
-        case "responses":
+        case 'responses':
           if (!this.generated.components) {
             this.generated.components = this.newObject(pointer);
           }
           this.generated.components.responses = this.newObject(pointer);
           await this.visitResponsesDefinitions(children, globalProduces);
           break;
-        case "securityDefinitions":
+        case 'securityDefinitions':
           if (!this.generated.components) {
             this.generated.components = this.newObject(pointer);
           }
@@ -190,14 +189,14 @@ export class Oai2ToOai3 {
           await this.visitSecurityDefinitions(children);
           break;
         // no changes to security from OA2 to OA3
-        case "security":
+        case 'security':
           this.generated.security = { value, pointer, recurse: true };
           break;
-        case "tags":
+        case 'tags':
           this.generated.tags = this.newArray(pointer);
           await this.visitTags(children);
           break;
-        case "externalDocs":
+        case 'externalDocs':
           this.visitExternalDocs(this.generated, key, value, pointer);
           break;
         default:
@@ -211,7 +210,7 @@ export class Oai2ToOai3 {
 
   async visitParameterDefinitions(parameters: Iterable<Node>) {
     for (const { key, value, pointer, childIterator } of parameters) {
-      if (value.in !== "formData" && value.in !== "body" && value.type !== "file") {
+      if (value.in !== 'formData' && value.in !== 'body' && value.type !== 'file') {
         if (this.generated.components === undefined) {
           this.generated.components = this.newObject(pointer);
         }
@@ -224,34 +223,31 @@ export class Oai2ToOai3 {
 
         this.generated.components.parameters[cleanParamName] = this.newObject(pointer);
         await this.visitParameter(this.generated.components.parameters[cleanParamName], value, pointer, childIterator);
-      }
+      } 
     }
   }
 
-  async visitParameter(
-    parameterTarget: any,
-    parameterValue: any,
-    pointer: string,
-    parameterItemMembers: () => Iterable<Node>,
-  ) {
+
+  async visitParameter(parameterTarget: any, parameterValue: any, pointer: string, parameterItemMembers: () => Iterable<Node>) {
     if (parameterValue.$ref !== undefined) {
       parameterTarget.$ref = { value: await this.convertReferenceToOai3(parameterValue.$ref), pointer };
     } else {
+
       const parameterUnchangedProperties = [
-        "name",
-        "in",
-        "description",
-        "allowEmptyValue",
-        "required",
-        "x-ms-parameter-location",
-        "x-ms-api-version",
-        "x-comment",
-        "x-ms-parameter-grouping",
-        "x-ms-client-name",
-        "x-ms-client-default",
-        "x-ms-client-flatten",
-        "x-ms-client-request-id",
-        "x-ms-header-collection-prefix",
+        'name',
+        'in',
+        'description',
+        'allowEmptyValue',
+        'required',
+        'x-ms-parameter-location',
+        'x-ms-api-version',
+        'x-comment',
+        'x-ms-parameter-grouping',
+        'x-ms-client-name',
+        'x-ms-client-default',
+        'x-ms-client-flatten',
+        'x-ms-client-request-id',
+        'x-ms-header-collection-prefix'
       ];
 
       for (const key of parameterUnchangedProperties) {
@@ -260,47 +256,41 @@ export class Oai2ToOai3 {
         }
       }
 
-      if (parameterValue["x-ms-skip-url-encoding"] !== undefined) {
-        if (parameterValue.in === "query") {
+      if (parameterValue['x-ms-skip-url-encoding'] !== undefined) {
+        if (parameterValue.in === 'query') {
           parameterTarget.allowReserved = { value: true, pointer };
         } else {
-          parameterTarget["x-ms-skip-url-encoding"] = { value: parameterValue["x-ms-skip-url-encoding"], pointer };
+          parameterTarget['x-ms-skip-url-encoding'] = { value: parameterValue['x-ms-skip-url-encoding'], pointer };
         }
       }
 
       // Collection Format
-      if (parameterValue.type === "array") {
-        parameterValue.collectionFormat = parameterValue.collectionFormat || "csv";
-        if (
-          parameterValue.collectionFormat === "csv" &&
-          (parameterValue.in === "query" || parameterValue.in === "cookie")
-        ) {
-          parameterTarget.style = { value: "form", pointer };
+      if (parameterValue.type === 'array') {
+        parameterValue.collectionFormat = parameterValue.collectionFormat || 'csv';
+        if ((parameterValue.collectionFormat === 'csv') && ((parameterValue.in === 'query') || (parameterValue.in === 'cookie'))) {
+          parameterTarget.style = { value: 'form', pointer };
         }
-        if (
-          parameterValue.collectionFormat === "csv" &&
-          (parameterValue.in === "path" || parameterValue.in === "header")
-        ) {
-          parameterTarget.style = { value: "simple", pointer };
+        if ((parameterValue.collectionFormat === 'csv') && ((parameterValue.in === 'path') || (parameterValue.in === 'header'))) {
+          parameterTarget.style = { value: 'simple', pointer };
         }
-        if (parameterValue.collectionFormat === "ssv") {
-          if (parameterValue.in === "query") {
-            parameterTarget.style = { value: "spaceDelimited", pointer };
+        if (parameterValue.collectionFormat === 'ssv') {
+          if (parameterValue.in === 'query') {
+            parameterTarget.style = { value: 'spaceDelimited', pointer };
           }
         }
-        if (parameterValue.collectionFormat === "pipes") {
-          if (parameterValue.in === "query") {
-            parameterTarget.style = { value: "pipeDelimited", pointer };
+        if (parameterValue.collectionFormat === 'pipes') {
+          if (parameterValue.in === 'query') {
+            parameterTarget.style = { value: 'pipeDelimited', pointer };
           }
         }
-        if (parameterValue.collectionFormat === "multi") {
-          parameterTarget.style = { value: "form", pointer };
+        if (parameterValue.collectionFormat === 'multi') {
+          parameterTarget.style = { value: 'form', pointer };
           parameterTarget.explode = { value: true, pointer };
         }
 
         // tsv is no longer supported in OAI3, but we still need to support this.
-        if (parameterValue.collectionFormat === "tsv") {
-          parameterTarget.style = { value: "tabDelimited", pointer };
+        if (parameterValue.collectionFormat === 'tsv') {
+          parameterTarget.style = { value: 'tabDelimited', pointer };
         }
       }
 
@@ -309,25 +299,25 @@ export class Oai2ToOai3 {
       }
 
       const schemaKeys = [
-        "maximum",
-        "exclusiveMaximum",
-        "minimum",
-        "exclusiveMinimum",
-        "maxLength",
-        "minLength",
-        "pattern",
-        "maxItems",
-        "minItems",
-        "uniqueItems",
-        "enum",
-        "x-ms-enum",
-        "multipleOf",
-        "default",
-        "format",
+        'maximum',
+        'exclusiveMaximum',
+        'minimum',
+        'exclusiveMinimum',
+        'maxLength',
+        'minLength',
+        'pattern',
+        'maxItems',
+        'minItems',
+        'uniqueItems',
+        'enum',
+        'x-ms-enum',
+        'multipleOf',
+        'default',
+        'format',
       ];
 
       for (const { key, childIterator, pointer: jsonPointer } of parameterItemMembers()) {
-        if (key === "schema") {
+        if (key === 'schema') {
           if (parameterTarget.schema.items === undefined) {
             parameterTarget.schema.items = this.newObject(jsonPointer);
           }
@@ -337,6 +327,7 @@ export class Oai2ToOai3 {
         }
       }
 
+
       if (parameterValue.type !== undefined) {
         parameterTarget.schema.type = { value: parameterValue.type, pointer };
       }
@@ -344,7 +335,7 @@ export class Oai2ToOai3 {
       if (parameterValue.items !== undefined) {
         parameterTarget.schema.items = this.newObject(pointer);
         for (const { key, childIterator } of parameterItemMembers()) {
-          if (key === "items") {
+          if (key === 'items') {
             await this.visitSchema(parameterTarget.schema.items, parameterValue.items, childIterator);
           }
         }
@@ -355,12 +346,12 @@ export class Oai2ToOai3 {
   async visitInfo(info: Iterable<Node>) {
     for (const { value, key, pointer, children } of info) {
       switch (key) {
-        case "title":
-        case "description":
-        case "termsOfService":
-        case "contact":
-        case "license":
-        case "version":
+        case 'title':
+        case 'description':
+        case 'termsOfService':
+        case 'contact':
+        case 'license':
+        case 'version':
           this.generated.info[key] = { value, pointer };
           break;
         default:
@@ -371,22 +362,17 @@ export class Oai2ToOai3 {
   }
 
   async visitSecurityDefinitions(securityDefinitions: Iterable<Node>) {
-    for (const {
-      key: schemeName,
-      value: v,
-      pointer: jsonPointer,
-      children: securityDefinitionsItemMembers,
-    } of securityDefinitions) {
+    for (const { key: schemeName, value: v, pointer: jsonPointer, children: securityDefinitionsItemMembers } of securityDefinitions) {
       this.generated.components.securitySchemes[schemeName] = this.newObject(jsonPointer);
       const securityScheme = this.generated.components.securitySchemes[schemeName];
       switch (v.type) {
-        case "apiKey":
+        case 'apiKey':
           for (const { key, value, pointer } of securityDefinitionsItemMembers) {
             switch (key) {
-              case "type":
-              case "description":
-              case "name":
-              case "in":
+              case 'type':
+              case 'description':
+              case 'name':
+              case 'in':
                 securityScheme[key] = { value, pointer };
                 break;
               default:
@@ -395,15 +381,15 @@ export class Oai2ToOai3 {
             }
           }
           break;
-        case "basic":
+        case 'basic':
           for (const { key, value, pointer } of securityDefinitionsItemMembers) {
             switch (key) {
-              case "description":
+              case 'description':
                 securityScheme.description = { value, pointer };
                 break;
-              case "type":
-                securityScheme.type = { value: "http", pointer };
-                securityScheme.scheme = { value: "basic", pointer };
+              case 'type':
+                securityScheme.type = { value: 'http', pointer };
+                securityScheme.scheme = { value: 'basic', pointer };
                 break;
               default:
                 await this.visitExtensions(securityScheme, key, value, pointer);
@@ -411,7 +397,7 @@ export class Oai2ToOai3 {
             }
           }
           break;
-        case "oauth2":
+        case 'oauth2':
           {
             if (v.description !== undefined) {
               securityScheme.description = { value: v.description, pointer: jsonPointer };
@@ -422,12 +408,12 @@ export class Oai2ToOai3 {
             let flowName = v.flow;
 
             // convert flow names to OpenAPI 3 flow names
-            if (v.flow === "application") {
-              flowName = "clientCredentials";
+            if (v.flow === 'application') {
+              flowName = 'clientCredentials';
             }
 
-            if (v.flow === "accessCode") {
-              flowName = "authorizationCode";
+            if (v.flow === 'accessCode') {
+              flowName = 'authorizationCode';
             }
 
             securityScheme.flows[flowName] = this.newObject(jsonPointer);
@@ -435,12 +421,12 @@ export class Oai2ToOai3 {
             let tokenUrl;
 
             if (v.authorizationUrl) {
-              authorizationUrl = v.authorizationUrl.split("?")[0].trim() || "/";
+              authorizationUrl = v.authorizationUrl.split('?')[0].trim() || '/';
               securityScheme.flows[flowName].authorizationUrl = { value: authorizationUrl, pointer: jsonPointer };
             }
 
             if (v.tokenUrl) {
-              tokenUrl = v.tokenUrl.split("?")[0].trim() || "/";
+              tokenUrl = v.tokenUrl.split('?')[0].trim() || '/';
               securityScheme.flows[flowName].tokenUrl = { value: tokenUrl, pointer: jsonPointer };
             }
 
@@ -453,12 +439,7 @@ export class Oai2ToOai3 {
   }
 
   async visitDefinitions(definitions: Iterable<Node>) {
-    for (const {
-      key: schemaName,
-      value: schemaValue,
-      pointer: jsonPointer,
-      childIterator: definitionsItemMembers,
-    } of definitions) {
+    for (const { key: schemaName, value: schemaValue, pointer: jsonPointer, childIterator: definitionsItemMembers } of definitions) {
       if (this.generated.components === undefined) {
         this.generated.components = this.newObject(jsonPointer);
       }
@@ -467,7 +448,7 @@ export class Oai2ToOai3 {
         this.generated.components.schemas = this.newObject(jsonPointer);
       }
 
-      const cleanSchemaName = schemaName.replace(/\[|\]/g, "_");
+      const cleanSchemaName = schemaName.replace(/\[|\]/g, '_');
       this.generated.components.schemas[cleanSchemaName] = this.newObject(jsonPointer);
       const schemaItem = this.generated.components.schemas[cleanSchemaName];
       await this.visitSchema(schemaItem, schemaValue, definitionsItemMembers);
@@ -498,11 +479,11 @@ export class Oai2ToOai3 {
   async visitSchema(target: any, schemaValue: any, schemaItemMemebers: () => Iterable<Node>) {
     for (const { key, value, pointer, childIterator } of schemaItemMemebers()) {
       switch (key) {
-        case "$ref":
+        case '$ref':
           target.$ref = { value: await this.convertReferenceToOai3(value), pointer };
           break;
-        case "additionalProperties":
-          if (typeof value === "boolean") {
+        case 'additionalProperties':
+          if (typeof (value) === 'boolean') {
             if (value === true) {
               target[key] = { value, pointer };
             } // false is assumed anyway in autorest.
@@ -511,66 +492,66 @@ export class Oai2ToOai3 {
             await this.visitSchema(target[key], value, childIterator);
           }
           break;
-        case "required":
-        case "title":
-        case "description":
-        case "default":
-        case "multipleOf":
-        case "maximum":
-        case "exclusiveMaximum":
-        case "minimum":
-        case "exclusiveMinimum":
-        case "maxLength":
-        case "minLength":
-        case "pattern":
-        case "maxItems":
-        case "minItems":
-        case "uniqueItems":
-        case "maxProperties":
-        case "minProperties":
-        case "enum":
-        case "readOnly":
+        case 'required':
+        case 'title':
+        case 'description':
+        case 'default':
+        case 'multipleOf':
+        case 'maximum':
+        case 'exclusiveMaximum':
+        case 'minimum':
+        case 'exclusiveMinimum':
+        case 'maxLength':
+        case 'minLength':
+        case 'pattern':
+        case 'maxItems':
+        case 'minItems':
+        case 'uniqueItems':
+        case 'maxProperties':
+        case 'minProperties':
+        case 'enum':
+        case 'readOnly':
           target[key] = { value, pointer, recurse: true };
           break;
-        case "allOf":
+        case 'allOf':
           target.allOf = this.newArray(pointer);
           await this.visitAllOf(target.allOf, childIterator);
           break;
-        case "items":
+        case 'items':
           target[key] = this.newObject(pointer);
           await this.visitSchema(target[key], value, childIterator);
           break;
-        case "properties":
+        case 'properties':
           target[key] = this.newObject(pointer);
           await this.visitProperties(target[key], childIterator);
           break;
-        case "type":
-        case "format":
+        case 'type':
+        case 'format':
           target[key] = { value, pointer };
           break;
         // in OpenAPI 3 the discriminator its an object instead of a string.
-        case "discriminator":
+        case 'discriminator':
           target.discriminator = this.newObject(pointer);
           target.discriminator.propertyName = { value, pointer };
           break;
-        case "xml":
+        case 'xml':
           this.visitXml(target, key, value, pointer);
           break;
-        case "externalDocs":
+        case 'externalDocs':
           this.visitExternalDocs(target, key, value, pointer);
           break;
-        case "example":
+        case 'example':
           target.example = { value, pointer, recurse: true };
           break;
-        case "x-nullable":
-          target["nullable"] = { value, pointer };
+        case 'x-nullable':
+          target['nullable'] = { value, pointer };
 
           // NOTE: this matches the previous converter behavior ... when a $ref
           // is inside the schema copy the properties as they are don't update
           // names, but also leave the new `nullable` field so that OpenAPI 3
           // readers pick it up correctly.
           if (schemaValue.$ref !== undefined) {
-            target["x-nullable"] = { value, pointer };
+            target['x-nullable'] = { value, pointer };
           }
           break;
         default:
@@ -618,11 +599,11 @@ export class Oai2ToOai3 {
 
     for (const { key, pointer, value } of tagItemMembers) {
       switch (key) {
-        case "name":
-        case "description":
+        case 'name':
+        case 'description':
           this.generated.tags[index][key] = { value, pointer };
           break;
-        case "externalDocs":
+        case 'externalDocs':
           this.visitExternalDocs(this.generated.tags[index], key, value, pointer);
           break;
         default:
@@ -637,7 +618,7 @@ export class Oai2ToOai3 {
   }
 
   private async resolveReference(file: string, path: string): Promise<any | undefined> {
-    if (file === "" || file === this.originalFilename) {
+    if(file === "" || file === this.originalFilename) {
       return get(this.original, path);
     } else {
       if (this.resolveExternalReference) {
@@ -649,7 +630,7 @@ export class Oai2ToOai3 {
 
   async visitExtensions(target: any, key: string, value: any, pointer: string) {
     switch (key) {
-      case "x-ms-odata":
+      case 'x-ms-odata':
         target[key] = { value: await this.convertReferenceToOai3(value), pointer };
         break;
       default:
@@ -682,43 +663,28 @@ export class Oai2ToOai3 {
     }
   }
 
-  async visitPath(
-    target: any,
-    uri: string,
-    jsonPointer: JsonPointer,
-    pathItemMembers: Iterable<Node>,
-    globalConsumes: Array<string>,
-    globalProduces: Array<string>,
-  ) {
+  async visitPath(target: any, uri: string, jsonPointer: JsonPointer, pathItemMembers: Iterable<Node>, globalConsumes: Array<string>, globalProduces: Array<string>) {
     target[uri] = this.newObject(jsonPointer);
     const pathItem = target[uri];
     for (const { value, key, pointer, children: pathItemFieldMembers } of pathItemMembers) {
       // handle each item in the path object
       switch (key) {
-        case "$ref":
-        case "x-summary":
-        case "x-description":
+        case '$ref':
+        case 'x-summary':
+        case 'x-description':
           pathItem[key] = { value, pointer };
           break;
-        case "get":
-        case "put":
-        case "post":
-        case "delete":
-        case "options":
-        case "head":
-        case "patch":
-        case "x-trace":
-          await this.visitOperation(
-            pathItem,
-            key,
-            pointer,
-            pathItemFieldMembers,
-            value,
-            globalConsumes,
-            globalProduces,
-          );
+        case 'get':
+        case 'put':
+        case 'post':
+        case 'delete':
+        case 'options':
+        case 'head':
+        case 'patch':
+        case 'x-trace':
+          await this.visitOperation(pathItem, key, pointer, pathItemFieldMembers, value, globalConsumes, globalProduces);
           break;
-        case "parameters":
+        case 'parameters':
           pathItem.parameters = this.newArray(pointer);
           await this.visitPathParameters(pathItem.parameters, pathItemFieldMembers);
           break;
@@ -733,17 +699,10 @@ export class Oai2ToOai3 {
     }
   }
 
-  async visitOperation(
-    pathItem: any,
-    httpMethod: HttpMethod | HttpMethodCustom,
-    jsonPointer: JsonPointer,
-    operationItemMembers: Iterable<Node>,
-    operationValue: OpenAPI2Operation,
-    globalConsumes: Array<string>,
-    globalProduces: Array<string>,
-  ) {
+  async visitOperation(pathItem: any, httpMethod: string, jsonPointer: JsonPointer, operationItemMembers: Iterable<Node>, operationValue: OpenAPI2Operation, globalConsumes: Array<string>, globalProduces: Array<string>) {
+
     // trace was not supported on OpenAPI 2.0, it was an extension
-    httpMethod = httpMethod !== "x-trace" ? httpMethod : "trace";
+    httpMethod = (httpMethod !== 'x-trace') ? httpMethod : 'trace';
     pathItem[httpMethod] = this.newObject(jsonPointer);
 
     // handle a single operation.
@@ -751,36 +710,36 @@ export class Oai2ToOai3 {
 
     // preprocess produces and consumes for responses and parameters respectively;
     const produces = resolveOperationProduces(jsonPointer, operationValue, globalProduces);
-    const consumes = resolveOperationConsumes(operationValue, globalProduces);
+    const consumes = resolveOperationConsumes(operationValue, globalConsumes);
 
     for (const { value, key, pointer, children: operationFieldItemMembers } of operationItemMembers) {
       switch (key) {
-        case "tags":
-        case "description":
-        case "summary":
-        case "operationId":
-        case "deprecated":
+        case 'tags':
+        case 'description':
+        case 'summary':
+        case 'operationId':
+        case 'deprecated':
           operation[key] = { value, pointer };
           break;
-        case "externalDocs":
+        case 'externalDocs':
           this.visitExternalDocs(operation, key, value, pointer);
           break;
-        case "consumes":
+        case 'consumes':
           // handled beforehand for parameters
           break;
-        case "parameters":
+        case 'parameters':
           await this.visitParameters(operation, operationFieldItemMembers, consumes, pointer);
           break;
-        case "produces":
+        case 'produces':
           // handled beforehand for responses
           break;
-        case "responses":
+        case 'responses':
           operation.responses = this.newObject(pointer);
           await this.visitResponses(operation.responses, operationFieldItemMembers, produces);
           break;
-        case "schemes":
+        case 'schemes':
           break;
-        case "security":
+        case 'security':
           operation.security = { value, pointer, recurse: true };
           break;
         default:
@@ -791,24 +750,17 @@ export class Oai2ToOai3 {
   }
 
   async visitParameters(targetOperation: any, parametersFieldItemMembers: any, consumes: any, pointer: string) {
-    const requestBodyTracker = {
-      xmsname: undefined,
-      name: undefined,
-      description: undefined,
-      index: -1,
-      keepTrackingIndex: true,
-      wasSpecialParameterFound: false,
-      wasParamRequired: false,
-    };
+    const requestBodyTracker = { xmsname: undefined, name: undefined, description: undefined, index: -1, keepTrackingIndex: true, wasSpecialParameterFound: false, wasParamRequired: false };
 
+    
     for (let { pointer, value, childIterator } of parametersFieldItemMembers) {
       if (value.$ref) {
         const parsedRef = parseOai2Ref(value.$ref);
-        if (parsedRef === undefined) {
+        if(parsedRef === undefined) {
           throw new Error(`Reference ${value.$ref} is not a valid ref(at ${pointer})`);
         }
         const parameterName = parsedRef.componentName;
-        if (parsedRef.basePath === "/parameters/") {
+        if(parsedRef.basePath === "/parameters/") {
           // TODO: I think we don't need this at all and can just call the else. TO check when adding the unit tests.
           if (parsedRef.file == "" || parsedRef.file === this.originalFilename) {
             const dereferencedParameter = get(this.original, parsedRef.path);
@@ -844,26 +796,26 @@ export class Oai2ToOai3 {
         }
       }
 
-      if (value.in === "body" || value.type === "file" || value.in === "formData") {
+      if (value.in === 'body' || value.type === 'file' || value.in === 'formData') {
         if (!requestBodyTracker.wasSpecialParameterFound && value.description !== undefined) {
           requestBodyTracker.description = value.description;
         } else {
           requestBodyTracker.description = undefined;
         }
 
-        if (value["x-ms-client-name"]) {
-          requestBodyTracker.xmsname = value["x-ms-client-name"];
+        if (value['x-ms-client-name']) {
+          requestBodyTracker.xmsname = value['x-ms-client-name'];
         } else if (value.name) {
           requestBodyTracker.name = value.name;
         }
 
-        if ((value.in === "body" || value.type === "file") && value.in !== "formData") {
+        if ((value.in === 'body' || value.type === 'file') && value.in !== 'formData') {
           requestBodyTracker.wasParamRequired = value.required;
         }
       }
 
       if (requestBodyTracker.keepTrackingIndex) {
-        if (!(value.in === "body" || value.type === "file" || value.in === "formData")) {
+        if (!(value.in === 'body' || value.type === 'file' || value.in === 'formData')) {
           if (requestBodyTracker.wasSpecialParameterFound) {
             requestBodyTracker.keepTrackingIndex = false;
           }
@@ -880,6 +832,8 @@ export class Oai2ToOai3 {
     }
 
     if (targetOperation.requestBody !== undefined) {
+
+
       if (requestBodyTracker.wasParamRequired) {
         targetOperation.requestBody.required = { value: requestBodyTracker.wasParamRequired, pointer };
       }
@@ -889,31 +843,27 @@ export class Oai2ToOai3 {
       }
 
       if (requestBodyTracker.xmsname) {
-        if (targetOperation.requestBody["x-ms-client-name"] === undefined) {
-          targetOperation.requestBody["x-ms-client-name"] = { value: requestBodyTracker.xmsname, pointer };
+        if (targetOperation.requestBody['x-ms-client-name'] === undefined) {
+          targetOperation.requestBody['x-ms-client-name'] = { value: requestBodyTracker.xmsname, pointer };
         }
 
-        targetOperation.requestBody["x-ms-requestBody-name"] = { value: requestBodyTracker.xmsname, pointer };
+        targetOperation.requestBody['x-ms-requestBody-name'] = { value: requestBodyTracker.xmsname, pointer };
       } else if (requestBodyTracker.name) {
-        targetOperation.requestBody["x-ms-requestBody-name"] = { value: requestBodyTracker.name, pointer };
+        targetOperation.requestBody['x-ms-requestBody-name'] = { value: requestBodyTracker.name, pointer };
       }
 
       if (targetOperation.parameters === undefined) {
-        targetOperation["x-ms-requestBody-index"] = { value: 0, pointer };
+        targetOperation['x-ms-requestBody-index'] = { value: 0, pointer };
+
       } else {
-        targetOperation["x-ms-requestBody-index"] = { value: requestBodyTracker.index, pointer };
+        targetOperation['x-ms-requestBody-index'] = { value: requestBodyTracker.index, pointer };
       }
     }
   }
 
-  async visitOperationParameter(
-    targetOperation: any,
-    parameterValue: any,
-    pointer: string,
-    parameterItemMembers: () => Iterable<Node>,
-    consumes: Array<any>,
-  ) {
-    if (parameterValue.in === "formData" || parameterValue.in === "body" || parameterValue.type === "file") {
+  async visitOperationParameter(targetOperation: any, parameterValue: any, pointer: string, parameterItemMembers: () => Iterable<Node>, consumes: Array<any>) {
+    if (parameterValue.in === 'formData' || parameterValue.in === 'body' || parameterValue.type === 'file') {
+
       if (targetOperation.requestBody === undefined) {
         targetOperation.requestBody = this.newObject(pointer);
       }
@@ -922,35 +872,27 @@ export class Oai2ToOai3 {
         targetOperation.requestBody.content = this.newObject(pointer);
       }
 
-      if (
-        parameterValue["x-ms-parameter-location"] &&
-        targetOperation.requestBody["x-ms-parameter-location"] === undefined
-      ) {
-        targetOperation.requestBody["x-ms-parameter-location"] = {
-          value: parameterValue["x-ms-parameter-location"],
-          pointer,
-        };
+      if (parameterValue['x-ms-parameter-location'] && targetOperation.requestBody['x-ms-parameter-location'] === undefined) {
+        targetOperation.requestBody['x-ms-parameter-location'] = { value: parameterValue['x-ms-parameter-location'], pointer };
       }
 
-      if (
-        parameterValue["x-ms-client-flatten"] !== undefined &&
-        targetOperation.requestBody["x-ms-client-flatten"] === undefined
-      ) {
-        targetOperation.requestBody["x-ms-client-flatten"] = { value: parameterValue["x-ms-client-flatten"], pointer };
+      if (parameterValue['x-ms-client-flatten'] !== undefined && targetOperation.requestBody['x-ms-client-flatten'] === undefined) {
+        targetOperation.requestBody['x-ms-client-flatten'] = { value: parameterValue['x-ms-client-flatten'], pointer };
       }
 
-      if (parameterValue["x-ms-enum"] !== undefined && targetOperation.requestBody["x-ms-enum"] === undefined) {
-        targetOperation.requestBody["x-ms-enum"] = { value: parameterValue["x-ms-enum"], pointer };
+      if (parameterValue['x-ms-enum'] !== undefined && targetOperation.requestBody['x-ms-enum'] === undefined) {
+        targetOperation.requestBody['x-ms-enum'] = { value: parameterValue['x-ms-enum'], pointer };
       }
 
       if (parameterValue.allowEmptyValue !== undefined && targetOperation.requestBody.allowEmptyValue === undefined) {
         targetOperation.requestBody.allowEmptyValue = { value: parameterValue.allowEmptyValue, pointer };
       }
 
-      if (parameterValue.in === "formData") {
-        let contentType = "application/x-www-form-urlencoded";
-        if (consumes.length && consumes.indexOf("multipart/form-data") >= 0) {
-          contentType = "multipart/form-data";
+      if (parameterValue.in === 'formData') {
+
+        let contentType = 'application/x-www-form-urlencoded';
+        if ((consumes.length) && (consumes.indexOf('multipart/form-data') >= 0)) {
+          contentType = 'multipart/form-data';
         }
 
         if (targetOperation.requestBody.content[contentType] === undefined) {
@@ -963,14 +905,14 @@ export class Oai2ToOai3 {
 
         if (parameterValue.schema !== undefined) {
           for (const { key, value, childIterator } of parameterItemMembers()) {
-            if (key === "schema") {
+            if (key === 'schema') {
               await this.visitSchema(targetOperation.requestBody.content[contentType].schema, value, childIterator);
             }
           }
         } else {
           const schema = targetOperation.requestBody.content[contentType].schema;
           if (schema.type === undefined) {
-            schema.type = { value: "object", pointer };
+            schema.type = { value: 'object', pointer };
           }
 
           if (schema.properties === undefined) {
@@ -989,9 +931,9 @@ export class Oai2ToOai3 {
 
           if (parameterValue.type !== undefined) {
             // OpenAPI 3 wants to see `type: file` as `type:string` with `format: binary`
-            if (parameterValue.type === "file") {
-              targetProperty.type = { value: "string", pointer };
-              targetProperty.format = { value: "binary", pointer };
+            if (parameterValue.type === 'file') {
+              targetProperty.type = { value: 'string', pointer };
+              targetProperty.format = { value: 'binary', pointer };
             } else {
               targetProperty.type = { value: parameterValue.type, pointer };
             }
@@ -1017,12 +959,12 @@ export class Oai2ToOai3 {
             targetProperty.allOf = { value: parameterValue.allOf, pointer };
           }
 
-          if (parameterValue.type === "array" && parameterValue.items !== undefined) {
+          if (parameterValue.type === 'array' && parameterValue.items !== undefined) {
             // Support the case where an operation can accept multiple files
-            if (contentType === "multipart/form-data" && parameterValue.items.type === "file") {
+            if (contentType === 'multipart/form-data' && parameterValue.items.type === 'file') {
               targetProperty.items = this.newObject(pointer);
-              targetProperty.items.type = { value: "string", pointer: `${pointer}/items` };
-              targetProperty.items.format = { value: "binary", pointer: `${pointer}/items` };
+              targetProperty.items.type = { value: 'string', pointer: `${pointer}/items` };
+              targetProperty.items.format = { value: 'binary', pointer: `${pointer}/items` };
             } else {
               targetProperty.items = { value: parameterValue.items, pointer };
             }
@@ -1030,22 +972,24 @@ export class Oai2ToOai3 {
 
           // copy extensions in target property
           for (const { key, pointer: fieldPointer, value } of parameterItemMembers()) {
-            if (key.startsWith("x-")) {
+            if (key.startsWith('x-')) {
               targetProperty[key] = { value: value, pointer: fieldPointer };
             }
           }
         }
-      } else if (parameterValue.type === "file") {
-        targetOperation["application/octet-stream"] = this.newObject(pointer);
-        targetOperation["application/octet-stream"].schema = this.newObject(pointer);
-        targetOperation["application/octet-stream"].schema.type = { value: "string", pointer };
-        targetOperation["application/octet-stream"].schema.format = { value: "binary", pointer };
+      } else if (parameterValue.type === 'file') {
+
+        targetOperation['application/octet-stream'] = this.newObject(pointer);
+        targetOperation['application/octet-stream'].schema = this.newObject(pointer);
+        targetOperation['application/octet-stream'].schema.type = { value: 'string', pointer };
+        targetOperation['application/octet-stream'].schema.format = { value: 'binary', pointer };
       }
 
-      if (parameterValue.in === "body") {
+      if (parameterValue.in === 'body') {
+
         const consumesTempArray = [...consumes];
         if (consumesTempArray.length === 0) {
-          consumesTempArray.push("application/json");
+          consumesTempArray.push('application/json');
         }
 
         for (const mimetype of consumesTempArray) {
@@ -1059,18 +1003,19 @@ export class Oai2ToOai3 {
 
           if (parameterValue.schema !== undefined) {
             for (const { key, value, childIterator } of parameterItemMembers()) {
-              if (key === "schema") {
+              if (key === 'schema') {
                 await this.visitSchema(targetOperation.requestBody.content[mimetype].schema, value, childIterator);
               }
             }
           } else {
             targetOperation.requestBody.content[mimetype].schema = this.newObject(pointer);
           }
+
         }
 
         // copy extensions in requestBody
         for (const { key, pointer: fieldPointer, value } of parameterItemMembers()) {
-          if (key.startsWith("x-")) {
+          if (key.startsWith('x-')) {
             if (!targetOperation.requestBody[key]) {
               targetOperation.requestBody[key] = { value: value, pointer: fieldPointer };
             }
@@ -1093,7 +1038,7 @@ export class Oai2ToOai3 {
       target[key] = this.newObject(pointer);
       if (value.$ref) {
         target[key].$ref = { value: await this.convertReferenceToOai3(value.$ref), pointer };
-      } else if (key.startsWith("x-")) {
+      } else if (key.startsWith('x-')) {
         await this.visitExtensions(target[key], key, value, pointer);
       } else {
         await this.visitResponse(target[key], value, key, childIterator, pointer, produces);
@@ -1101,23 +1046,17 @@ export class Oai2ToOai3 {
     }
   }
 
-  async visitResponse(
-    responseTarget: any,
-    responseValue: any,
-    responseName: string,
-    responsesFieldMembers: () => Iterable<Node>,
-    jsonPointer: string,
-    produces: Array<string>,
-  ) {
+  async visitResponse(responseTarget: any, responseValue: any, responseName: string, responsesFieldMembers: () => Iterable<Node>, jsonPointer: string, produces: Array<string>) {
+
     // NOTE: The previous converter patches the description of the response because
     // every response should have a description.
     // So, to match previous behavior we do too.
-    if (responseValue.description === undefined || responseValue.description === "") {
+    if (responseValue.description === undefined || responseValue.description === '') {
       const sc = statusCodes.find((e) => {
         return e.code === responseName;
       });
 
-      responseTarget.description = { value: sc ? sc.phrase : "", pointer: jsonPointer };
+      responseTarget.description = { value: (sc ? sc.phrase : ''), pointer: jsonPointer };
     } else {
       responseTarget.description = { value: responseValue.description, pointer: jsonPointer };
     }
@@ -1128,7 +1067,7 @@ export class Oai2ToOai3 {
         responseTarget.content[mimetype] = this.newObject(jsonPointer);
         responseTarget.content[mimetype].schema = this.newObject(jsonPointer);
         for (const { key, value, childIterator } of responsesFieldMembers()) {
-          if (key === "schema") {
+          if (key === 'schema') {
             await this.visitSchema(responseTarget.content[mimetype].schema, value, childIterator);
           }
         }
@@ -1154,10 +1093,7 @@ export class Oai2ToOai3 {
       if (responseTarget.content[mimetype].examples === undefined) {
         responseTarget.content[mimetype].examples = this.newObject(jsonPointer);
         responseTarget.content[mimetype].examples.response = this.newObject(jsonPointer);
-        responseTarget.content[mimetype].examples.response.value = {
-          value: responseValue.examples[mimetype],
-          pointer: jsonPointer,
-        };
+        responseTarget.content[mimetype].examples.response.value = { value: responseValue.examples[mimetype], pointer: jsonPointer };
       }
     }
 
@@ -1169,36 +1105,42 @@ export class Oai2ToOai3 {
       }
     }
 
-    // copy extensions
+    // copy extensions 
     for (const { key, pointer: fieldPointer, value } of responsesFieldMembers()) {
-      if (key.startsWith("x-") && responseTarget[key] === undefined) {
+      if (key.startsWith('x-') && responseTarget[key] === undefined) {
         responseTarget[key] = { value: value, pointer: fieldPointer };
       }
     }
   }
 
+
   parameterTypeProperties = [
-    "format",
-    "minimum",
-    "maximum",
-    "exclusiveMinimum",
-    "exclusiveMaximum",
-    "minLength",
-    "maxLength",
-    "multipleOf",
-    "minItems",
-    "maxItems",
-    "uniqueItems",
-    "minProperties",
-    "maxProperties",
-    "additionalProperties",
-    "pattern",
-    "enum",
-    "x-ms-enum",
-    "default",
+    'format',
+    'minimum',
+    'maximum',
+    'exclusiveMinimum',
+    'exclusiveMaximum',
+    'minLength',
+    'maxLength',
+    'multipleOf',
+    'minItems',
+    'maxItems',
+    'uniqueItems',
+    'minProperties',
+    'maxProperties',
+    'additionalProperties',
+    'pattern',
+    'enum',
+    'x-ms-enum',
+    'default'
   ];
 
-  arrayProperties = ["items", "minItems", "maxItems", "uniqueItems"];
+  arrayProperties = [
+    'items',
+    'minItems',
+    'maxItems',
+    'uniqueItems'
+  ];
 
   async visitHeader(targetHeader: any, headerValue: any, jsonPointer: string) {
     if (headerValue.$ref) {
@@ -1213,11 +1155,11 @@ export class Oai2ToOai3 {
       }
 
       for (const { key, childIterator } of visit(headerValue)) {
-        if (key === "schema") {
+        if (key === 'schema') {
           await this.visitSchema(targetHeader.schema.items, headerValue.items, childIterator);
         } else if (this.parameterTypeProperties.includes(key) || this.arrayProperties.includes(key)) {
           targetHeader.schema[key] = { value: headerValue[key], pointer: jsonPointer, recurse: true };
-        } else if (key.startsWith("x-") && targetHeader[key] === undefined) {
+        } else if (key.startsWith('x-') && targetHeader[key] === undefined) {
           targetHeader[key] = { value: headerValue[key], pointer: jsonPointer, recurse: true };
         }
       }
@@ -1226,11 +1168,11 @@ export class Oai2ToOai3 {
         targetHeader.schema.type = { value: headerValue.type, pointer: jsonPointer };
       }
       if (headerValue.items && headerValue.items.collectionFormat) {
-        if (headerValue.collectionFormat === "csv") {
-          targetHeader.style = { value: "simple", pointer: jsonPointer };
+        if (headerValue.collectionFormat === 'csv') {
+          targetHeader.style = { value: 'simple', pointer: jsonPointer };
         }
 
-        if (headerValue.collectionFormat === "multi") {
+        if (headerValue.collectionFormat === 'multi') {
           targetHeader.explode = { value: true, pointer: jsonPointer };
         }
       }

--- a/oai2-to-oai3/src/oai2/definition.ts
+++ b/oai2-to-oai3/src/oai2/definition.ts
@@ -1,0 +1,33 @@
+export interface OpenAPI2Definition {
+  [key: string]: unknown; 
+
+  additionalProperties?: OpenAPI2Definition | OpenAPI2Reference | boolean;
+  allOf?: OpenAPI2Definition[];
+  description?: string;
+  enum?: string[];
+  format?: string;
+  items?: OpenAPI2Definition | OpenAPI2Reference;
+  oneOf?: (OpenAPI2Definition | OpenAPI2Reference)[];
+  properties?: { [index: string]: OpenAPI2Definition | OpenAPI2Reference };
+  required?: string[];
+  title?: string;
+  type?: OpenAPI2Type; // allow this to be optional to cover cases when this is missing
+}
+
+export interface OpenAPI2Reference {
+  $ref: string;
+}
+
+export type OpenAPI2Type =
+  | "array"
+  | "boolean"
+  | "byte"
+  | "date"
+  | "dateTime"
+  | "double"
+  | "float"
+  | "integer"
+  | "long"
+  | "number"
+  | "object"
+  | "string";

--- a/oai2-to-oai3/src/oai2/document.ts
+++ b/oai2-to-oai3/src/oai2/document.ts
@@ -1,0 +1,19 @@
+import { OpenAPI2Definition } from "./definition";
+import { OpenAPI2Path } from "./paths";
+
+export interface OpenAPI2Document {
+  swagger: "2.0";
+  produces?: string[];
+  consumes?: string[];
+  schemes?: string[];
+  host?: string;
+  basePath?: string;
+  paths: { [path: string]: OpenAPI2Path };
+  definitions: { [name: string]: OpenAPI2Definition };
+}
+
+export interface OpenAPI2DocumentInfo {
+  title: string;
+  description: string;
+  version: string;
+}

--- a/oai2-to-oai3/src/oai2/index.ts
+++ b/oai2-to-oai3/src/oai2/index.ts
@@ -1,0 +1,3 @@
+export * from "./document";
+export * from "./paths";
+export * from "./definition";

--- a/oai2-to-oai3/src/oai2/paths.ts
+++ b/oai2-to-oai3/src/oai2/paths.ts
@@ -1,0 +1,28 @@
+/**
+ * Custom http method verb for autorest.
+ */
+export type HttpMethodCustom = "x-trace";
+
+export type HttpMethod = "get" | "post" | "patch" | "put" | "delete" | "options" | "head" | "trace";
+
+export type OpenAPI2Path = {
+  [method in HttpMethod]: OpenAPI2Path;
+} & {
+  parameters: any[];
+};
+
+export interface OpenAPI2Operation {
+  operationId: string;
+  description: string;
+  responses: OpenAPI2OperationResponses;
+  parameters?: any[];
+  produces?: string[];
+  consumes?: string[];
+}
+
+export type OpenAPI2OperationResponses = { [statusCode: string]: OpenAPI2OperationResponse };
+
+export interface OpenAPI2OperationResponse {
+  description: string;
+  schema: any;
+}

--- a/oai2-to-oai3/src/oai2/paths.ts
+++ b/oai2-to-oai3/src/oai2/paths.ts
@@ -1,3 +1,5 @@
+import { OpenAPI2Definition, OpenAPI2Reference } from "./definition";
+
 /**
  * Custom http method verb for autorest.
  */
@@ -24,5 +26,17 @@ export type OpenAPI2OperationResponses = { [statusCode: string]: OpenAPI2Operati
 
 export interface OpenAPI2OperationResponse {
   description: string;
-  schema: any;
+  schema?: OpenAPI2Definition;
+  examples?: { [exampleName: string]: unknown };
+  headers?: { [headerName: string]: OpenAPI2Header };
+}
+
+export type OpenAPI2Header = OpenAPI2Reference & OpenAPI2HeaderDefinition;
+
+export interface OpenAPI2HeaderDefinition {
+  type: "string" | "number" | "integer" | "boolean" | "array";
+  schema: OpenAPI2Reference & OpenAPI2Definition;
+  description: string;
+  items: any;
+  collectionFormat: "csv" | "ssv" | "tsv" | "pipes" | "multi";
 }

--- a/oai2-to-oai3/src/runner/oai2-to-oai3-runner.ts
+++ b/oai2-to-oai3/src/runner/oai2-to-oai3-runner.ts
@@ -1,10 +1,11 @@
 import { DataHandle, get } from "@azure-tools/datastore";
 import { Oai2ToOai3 } from "../converter";
+import { OpenAPI2Document } from "../oai2";
 import { loadInputFiles } from "./utils";
 
 export interface OaiToOai3FileInput {
   name: string;
-  schema: any; // OAI2 type?
+  schema: OpenAPI2Document; // OAI2 type?
 }
 
 export interface OaiToOai3FileOutput {

--- a/oai2-to-oai3/src/runner/utils.ts
+++ b/oai2-to-oai3/src/runner/utils.ts
@@ -1,10 +1,11 @@
 import { DataHandle } from '@azure-tools/datastore';
+import { OpenAPI2Document } from '../oai2';
 import { OaiToOai3FileInput } from './oai2-to-oai3-runner';
 
 export const loadInputFiles = async (inputFiles: DataHandle[]): Promise<OaiToOai3FileInput[]> => {
   const inputs: OaiToOai3FileInput[] = [];
   for (const file of inputFiles) {
-    const schema = await file.ReadObject();
+    const schema = await file.ReadObject<OpenAPI2Document>();
     inputs.push({ name: file.originalFullPath, schema });
   }
   return inputs;

--- a/oai2-to-oai3/test/resources/conversion/oai2/exec-service.json
+++ b/oai2-to-oai3/test/resources/conversion/oai2/exec-service.json
@@ -5,6 +5,7 @@
     "title": "ExecService",
     "description": "Azure Dev Spaces ExecService v3.2"
   },
+  
   "paths": {
     "/api/v3.2/AzdsTraces": {
       "post": {
@@ -13,7 +14,7 @@
         ],
         "operationId": "AzdsTraces_PostAzdsUserClusterLogsAsync",
         "consumes": [],
-        "produces": [],
+        "produces": ["application/json"],
         "parameters": [
           {
             "name": "onbehalfof",
@@ -54,7 +55,7 @@
           "text/json",
           "application/*+json"
         ],
-        "produces": [],
+        "produces": ["application/json"],
         "parameters": [
           {
             "name": "spaceName",
@@ -151,7 +152,7 @@
         ],
         "operationId": "Liveness_LivenessCheck",
         "consumes": [],
-        "produces": [],
+        "produces": ["application/json"],
         "parameters": [],
         "responses": {
           "200": {
@@ -173,7 +174,7 @@
         ],
         "operationId": "Ping_CheckUserAuth",
         "consumes": [],
-        "produces": [],
+        "produces": ["application/json"],
         "parameters": [],
         "responses": {
           "200": {
@@ -201,7 +202,7 @@
         ],
         "operationId": "Ping_CheckWhitelistAndUserAuth",
         "consumes": [],
-        "produces": [],
+        "produces": ["application/json"],
         "parameters": [],
         "responses": {
           "200": {
@@ -229,7 +230,7 @@
         ],
         "operationId": "Ping_CheckWhitelistOnlyAuth",
         "consumes": [],
-        "produces": [],
+        "produces": ["application/json"],
         "parameters": [],
         "responses": {
           "200": {
@@ -286,7 +287,7 @@
         ],
         "operationId": "Spaces_CreateSpace",
         "consumes": [],
-        "produces": [],
+        "produces": ["application/json"],
         "parameters": [
           {
             "name": "spaceName",
@@ -325,7 +326,7 @@
         ],
         "operationId": "Spaces_DeleteSpace",
         "consumes": [],
-        "produces": [],
+        "produces": ["application/json"],
         "parameters": [
           {
             "name": "spaceName",
@@ -374,7 +375,7 @@
         ],
         "operationId": "Spaces_CreateSpaceFromNamespace",
         "consumes": [],
-        "produces": [],
+        "produces": ["application/json"],
         "parameters": [
           {
             "name": "namespaceName",
@@ -454,7 +455,7 @@
         ],
         "operationId": "Traces_ReportRequestAsync",
         "consumes": [],
-        "produces": [],
+        "produces": ["application/json"],
         "parameters": [],
         "responses": {
           "200": {
@@ -482,7 +483,7 @@
         ],
         "operationId": "Traces_ReportResponseAsync",
         "consumes": [],
-        "produces": [],
+        "produces": ["application/json"],
         "parameters": [],
         "responses": {
           "200": {

--- a/oai2-to-oai3/test/resources/conversion/oai3/exec-service.json
+++ b/oai2-to-oai3/test/resources/conversion/oai3/exec-service.json
@@ -37,7 +37,7 @@
           "default": {
             "description": "Error response describing the reason for operation failure. The request failed. Bad request.",
             "content": {
-              "*/*": {
+              "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ExecServiceErrorResponse"
                 }
@@ -92,7 +92,7 @@
           "default": {
             "description": "Error response describing the reason for operation failure. The request failed. Bad request.",
             "content": {
-              "*/*": {
+              "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ExecServiceErrorResponse"
                 }
@@ -207,7 +207,7 @@
           "default": {
             "description": "Error response describing the reason for operation failure. The service has run out of storage space",
             "content": {
-              "*/*": {
+              "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ExecServiceErrorResponse"
                 }
@@ -236,7 +236,7 @@
           "default": {
             "description": "Error response describing the reason for operation failure.",
             "content": {
-              "*/*": {
+              "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ExecServiceErrorResponse"
                 }
@@ -265,7 +265,7 @@
           "default": {
             "description": "Error response describing the reason for operation failure.",
             "content": {
-              "*/*": {
+              "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ExecServiceErrorResponse"
                 }
@@ -294,7 +294,7 @@
           "default": {
             "description": "Error response describing the reason for operation failure.",
             "content": {
-              "*/*": {
+              "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ExecServiceErrorResponse"
                 }
@@ -391,7 +391,7 @@
           "default": {
             "description": "Error response describing the reason for operation failure. The request failed. Space name is invalid.",
             "content": {
-              "*/*": {
+              "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ExecServiceErrorResponse"
                 }
@@ -446,7 +446,7 @@
           "default": {
             "description": "Error response describing the reason for operation failure. The request failed. Specified space cannot be deleted.",
             "content": {
-              "*/*": {
+              "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ExecServiceErrorResponse"
                 }
@@ -493,7 +493,7 @@
           "default": {
             "description": "Error response describing the reason for operation failure. The request failed. Bad request.",
             "content": {
-              "*/*": {
+              "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ExecServiceErrorResponse"
                 }
@@ -590,7 +590,7 @@
           "default": {
             "description": "Error response describing the reason for operation failure.",
             "content": {
-              "*/*": {
+              "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ExecServiceErrorResponse"
                 }
@@ -619,7 +619,7 @@
           "default": {
             "description": "Error response describing the reason for operation failure.",
             "content": {
-              "*/*": {
+              "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ExecServiceErrorResponse"
                 }

--- a/oai2-to-oai3/test/test-conversion.ts
+++ b/oai2-to-oai3/test/test-conversion.ts
@@ -9,6 +9,7 @@ import { FastStringify } from '@azure-tools/datastore';
 require('source-map-support').install();
 
 import { Oai2ToOai3 } from '../src/converter';
+import { OpenAPI2Document } from '../src/oai2';
 
 @suite class MyTests {
 
@@ -32,7 +33,7 @@ import { Oai2ToOai3 } from '../src/converter';
     assert(originalDataHandle != null);
 
     if (swaggerDataHandle && originalDataHandle) {
-      const swag = await swaggerDataHandle.ReadObject();
+      const swag = await swaggerDataHandle.ReadObject<OpenAPI2Document>();
       const original = await originalDataHandle.ReadObject();
       const convert = new Oai2ToOai3(swaggerUri, swag);
 
@@ -66,7 +67,7 @@ import { Oai2ToOai3 } from '../src/converter';
     assert(originalDataHandle != null);
 
     if (swaggerDataHandle && originalDataHandle) {
-      const swag = await swaggerDataHandle.ReadObject();
+      const swag = await swaggerDataHandle.ReadObject<OpenAPI2Document>();
       const original = await originalDataHandle.ReadObject();
       const convert = new Oai2ToOai3(swaggerUri, swag);
 
@@ -100,7 +101,7 @@ import { Oai2ToOai3 } from '../src/converter';
     assert(originalDataHandle != null);
 
     if (swaggerDataHandle && originalDataHandle) {
-      const swag = await swaggerDataHandle.ReadObject();
+      const swag = await swaggerDataHandle.ReadObject<OpenAPI2Document>();
       const original = await originalDataHandle.ReadObject();
       const convert = new Oai2ToOai3(swaggerUri, swag);
 
@@ -134,7 +135,7 @@ import { Oai2ToOai3 } from '../src/converter';
     assert(originalDataHandle != null);
 
     if (swaggerDataHandle && originalDataHandle) {
-      const swag = await swaggerDataHandle.ReadObject();
+      const swag = await swaggerDataHandle.ReadObject<OpenAPI2Document>();
       const original = await originalDataHandle.ReadObject();
       const convert = new Oai2ToOai3(swaggerUri, swag);
 
@@ -168,7 +169,7 @@ import { Oai2ToOai3 } from '../src/converter';
     assert(originalDataHandle != null);
 
     if (swaggerDataHandle && originalDataHandle) {
-      const swag = await swaggerDataHandle.ReadObject();
+      const swag = await swaggerDataHandle.ReadObject<OpenAPI2Document>();
       const original = await originalDataHandle.ReadObject();
       const convert = new Oai2ToOai3(swaggerUri, swag);
 
@@ -199,7 +200,7 @@ import { Oai2ToOai3 } from '../src/converter';
     assert(originalDataHandle != null);
 
     if (swaggerDataHandle && originalDataHandle) {
-      const swag = await swaggerDataHandle.ReadObject();
+      const swag = await swaggerDataHandle.ReadObject<OpenAPI2Document>();
       const original = await originalDataHandle.ReadObject();
       const convert = new Oai2ToOai3(swaggerUri, swag);
 
@@ -230,7 +231,7 @@ import { Oai2ToOai3 } from '../src/converter';
     assert(originalDataHandle != null);
 
     if (swaggerDataHandle && originalDataHandle) {
-      const swag = await swaggerDataHandle.ReadObject();
+      const swag = await swaggerDataHandle.ReadObject<OpenAPI2Document>();
       const original = await originalDataHandle.ReadObject();
       const convert = new Oai2ToOai3(swaggerUri, swag);
 
@@ -261,7 +262,7 @@ import { Oai2ToOai3 } from '../src/converter';
     assert(originalDataHandle != null);
 
     if (swaggerDataHandle && originalDataHandle) {
-      const swag = await swaggerDataHandle.ReadObject();
+      const swag = await swaggerDataHandle.ReadObject<OpenAPI2Document>();
       const original = await originalDataHandle.ReadObject();
       const convert = new Oai2ToOai3(swaggerUri, swag);
 
@@ -292,7 +293,7 @@ import { Oai2ToOai3 } from '../src/converter';
     assert(originalDataHandle != null);
 
     if (swaggerDataHandle && originalDataHandle) {
-      const swag = await swaggerDataHandle.ReadObject();
+      const swag = await swaggerDataHandle.ReadObject<OpenAPI2Document>();
       const original = await originalDataHandle.ReadObject();
       const convert = new Oai2ToOai3(swaggerUri, swag);
 
@@ -323,7 +324,7 @@ import { Oai2ToOai3 } from '../src/converter';
     assert(originalDataHandle != null);
 
     if (swaggerDataHandle && originalDataHandle) {
-      const swag = await swaggerDataHandle.ReadObject();
+      const swag = await swaggerDataHandle.ReadObject<OpenAPI2Document>();
       const original = await originalDataHandle.ReadObject();
       const convert = new Oai2ToOai3(swaggerUri, swag);
 
@@ -355,7 +356,7 @@ import { Oai2ToOai3 } from '../src/converter';
     assert(originalDataHandle != null);
 
     if (swaggerDataHandle && originalDataHandle) {
-      const swag = await swaggerDataHandle.ReadObject();
+      const swag = await swaggerDataHandle.ReadObject<OpenAPI2Document>();
       const original = await originalDataHandle.ReadObject();
       const convert = new Oai2ToOai3(swaggerUri, swag);
 
@@ -387,7 +388,7 @@ import { Oai2ToOai3 } from '../src/converter';
     assert(originalDataHandle != null);
 
     if (swaggerDataHandle && originalDataHandle) {
-      const swag = await swaggerDataHandle.ReadObject();
+      const swag = await swaggerDataHandle.ReadObject<OpenAPI2Document>();
       const original = await originalDataHandle.ReadObject();
       const convert = new Oai2ToOai3(swaggerUri, swag);
 
@@ -419,7 +420,7 @@ import { Oai2ToOai3 } from '../src/converter';
     assert(originalDataHandle != null);
 
     if (swaggerDataHandle && originalDataHandle) {
-      const swag = await swaggerDataHandle.ReadObject();
+      const swag = await swaggerDataHandle.ReadObject<OpenAPI2Document>();
       const original = await originalDataHandle.ReadObject();
       const convert = new Oai2ToOai3(swaggerUri, swag);
 
@@ -450,7 +451,7 @@ import { Oai2ToOai3 } from '../src/converter';
     assert(originalDataHandle != null);
 
     if (swaggerDataHandle && originalDataHandle) {
-      const swag = await swaggerDataHandle.ReadObject();
+      const swag = await swaggerDataHandle.ReadObject<OpenAPI2Document>();
       const original = await originalDataHandle.ReadObject();
       const convert = new Oai2ToOai3(swaggerUri, swag);
 
@@ -480,7 +481,7 @@ import { Oai2ToOai3 } from '../src/converter';
     assert(originalDataHandle != null);
 
     if (swaggerDataHandle && originalDataHandle) {
-      const swag = await swaggerDataHandle.ReadObject();
+      const swag = await swaggerDataHandle.ReadObject<OpenAPI2Document>();
       const original = await originalDataHandle.ReadObject();
       const convert = new Oai2ToOai3(swaggerUri, swag);
 
@@ -511,7 +512,7 @@ import { Oai2ToOai3 } from '../src/converter';
     assert(originalDataHandle != null);
 
     if (swaggerDataHandle && originalDataHandle) {
-      const swag = await swaggerDataHandle.ReadObject();
+      const swag = await swaggerDataHandle.ReadObject<OpenAPI2Document>();
       const original = await originalDataHandle.ReadObject();
       const convert = new Oai2ToOai3(swaggerUri, swag);
 
@@ -542,7 +543,7 @@ import { Oai2ToOai3 } from '../src/converter';
     assert(originalDataHandle != null);
 
     if (swaggerDataHandle && originalDataHandle) {
-      const swag = await swaggerDataHandle.ReadObject();
+      const swag = await swaggerDataHandle.ReadObject<OpenAPI2Document>();
       const original = await originalDataHandle.ReadObject();
       const convert = new Oai2ToOai3(swaggerUri, swag);
 
@@ -579,7 +580,7 @@ import { Oai2ToOai3 } from '../src/converter';
 
     assert(swaggerdata != null);
     if (swaggerdata) {
-      const swag = swaggerdata.ReadObject();
+      const swag = await swaggerdata.ReadObject<OpenAPI2Document>();
 
       const convert = new Oai2ToOai3(swaggerdata.key, swag);
       const result = await convert.convert();

--- a/oai2-to-oai3/test/test-conversion.ts
+++ b/oai2-to-oai3/test/test-conversion.ts
@@ -13,7 +13,7 @@ import { OpenAPI2Document } from '../src/oai2';
 
 @suite class MyTests {
 
-  @test.only  async 'test conversion - simple'() {
+  @test  async 'test conversion - simple'() {
     const swaggerUri = 'mem://swagger.yaml';
     const oai3Uri = 'mem://oai3.yaml';
 

--- a/oai2-to-oai3/test/test-conversion.ts
+++ b/oai2-to-oai3/test/test-conversion.ts
@@ -13,7 +13,7 @@ import { OpenAPI2Document } from '../src/oai2';
 
 @suite class MyTests {
 
-  @test  async 'test conversion - simple'() {
+  @test.only  async 'test conversion - simple'() {
     const swaggerUri = 'mem://swagger.yaml';
     const oai3Uri = 'mem://oai3.yaml';
 


### PR DESCRIPTION
Should resolve the confusion this cause later in the pipeline: Azure/autorest#3680

This is however a breaking change(Not really used inside of autorest as it would just fail later in the pipeline, so if we don't care about that we can do this)

Alternatives:
- Just log a warning. Cons: Easy to miss
- Add a parameter to enable this feature

Also include a few cleanup(including some basic typing for OAI2 schema)