### PR TITLE
pnpm publish skip git checks

### DIFF
--- a/.scripts/publish.yaml
+++ b/.scripts/publish.yaml
@@ -42,6 +42,10 @@ steps:
     npx @microsoft/rush publish --publish --pack --include-all --tag latest
     rc=$?; if [ $rc -ne 0 ]; then exit $rc ; fi 
 
+    # Git status(Next command might fail if there is modified files)
+    echo "Git status:"
+    git status
+
     # publish the packages (tag as preview by default)
     echo "//registry.npmjs.org/:_authToken=$(azure-sdk-npm-token)" > ./.npmrc 
     for file in common/temp/artifacts/packages/*.tgz 

--- a/.scripts/publish.yaml
+++ b/.scripts/publish.yaml
@@ -42,14 +42,13 @@ steps:
     npx @microsoft/rush publish --publish --pack --include-all --tag latest
     rc=$?; if [ $rc -ne 0 ]; then exit $rc ; fi 
 
-    # Git status(Next command might fail if there is modified files)
-    echo "Git status:"
-    git status
-
+- script: |
     # publish the packages (tag as preview by default)
     echo "//registry.npmjs.org/:_authToken=$(azure-sdk-npm-token)" > ./.npmrc 
     for file in common/temp/artifacts/packages/*.tgz 
     do
-     common/temp/pnpm-local/node_modules/.bin/pnpm publish $file --tag latest --access public || echo no-worries 
+      echo "Trying to publish $file:"
+      common/temp/pnpm-local/node_modules/.bin/pnpm publish $file --tag latest --access public --no-git-checks || echo no-worries 
     done
+  displayName: Publish packages
 


### PR DESCRIPTION
Seems like packages were not being published as there was modified files in the repository(All packages.json)
Most likely broke when I updated the version of rush/pnpm which must have introduced this functionality)