### PR TITLE
Fix @azure-tools/extension yarn path

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -111,16 +111,12 @@
       "directory": "./uri"
     }
   ],
-  "eslint.autoFixOnSave": true,
-  "eslint.validate": [
-    "javascript",
-    {
-      "language": "typescript",
-      "autoFix": true,
-    },
-    {
-      "language": "typescriptreact",
-      "autoFix": false
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  },
+  "[typescriptreact]": {
+    "editor.codeActionsOnSave": {
+      "source.fixAll.eslint": false
     }
-  ],
+  },
 }

--- a/extension/package.json
+++ b/extension/package.json
@@ -6,8 +6,8 @@
   "engines": {
     "node": ">=10.12.0"
   },
-  "main": "./dist/src/main.js",
-  "typings": "./dist/src/main.d.ts",
+  "main": "./dist/main.js",
+  "typings": "./dist/main.d.ts",
   "scripts": {
     "build": "tsc -p .",
     "watch": "tsc -p . --watch",

--- a/extension/tsconfig.build.json
+++ b/extension/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["**/*.test.*", "test/**/*"]
+}


### PR DESCRIPTION
Issue is that the path to `yarn/cli` counted for the compiled js to be directly under `dist` not under `dist/src`