### PR TITLE
Fix build root for @azure-tools/extension

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -9,8 +9,8 @@
   "main": "./dist/main.js",
   "typings": "./dist/main.d.ts",
   "scripts": {
-    "build": "tsc -p .",
-    "watch": "tsc -p . --watch",
+    "build": "tsc -p ./tsconfig.build.json",
+    "watch": "tsc -p ./tsconfig.build.json --watch",
     "eslint-fix": "eslint  . --fix --ext .ts",
     "eslint": "eslint  . --ext .ts",
     "prepare": "npm run build",

--- a/extension/package.json
+++ b/extension/package.json
@@ -6,11 +6,11 @@
   "engines": {
     "node": ">=10.12.0"
   },
-  "main": "./dist/main.js",
-  "typings": "./dist/main.d.ts",
+  "main": "./dist/src/main.js",
+  "typings": "./dist/src/main.d.ts",
   "scripts": {
-    "build": "tsc -p ./tsconfig.build.json",
-    "watch": "tsc -p ./tsconfig.build.json --watch",
+    "build": "tsc -p .",
+    "watch": "tsc -p . --watch",
     "eslint-fix": "eslint  . --fix --ext .ts",
     "eslint": "eslint  . --ext .ts",
     "prepare": "npm run build",

--- a/extension/src/yarn.ts
+++ b/extension/src/yarn.ts
@@ -8,7 +8,7 @@ import { InstallOptions, PackageManager } from "./package-manager";
 
 let _cli: string | undefined;
 const getPathToYarnCli = async () => {
-  const fname = resolve(`${__dirname}/../yarn/cli.js`);
+  const fname = resolve(`${__dirname}/../../yarn/cli.js`);
   if (await isFile(fname)) {
     _cli = fname;
   } else {

--- a/extension/tsconfig.build.json
+++ b/extension/tsconfig.build.json
@@ -1,4 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "exclude": ["**/*.test.*", "test/**/*"]
-}

--- a/extension/tsconfig.json
+++ b/extension/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "rootDir": ".",
     "outDir": "dist",
     "noImplicitAny": false
   },


### PR DESCRIPTION
Merged the previous PR too fast #151, it is not possible to move to dist diectly due to the mocha tests. Just updating instead the yarn loading path