### PR TITLE
[@azure-tools/uri] Rename functions to be camelCase and deprecate PascalCase ones

### DIFF
--- a/common/changes/@azure-tools/uri/deprecate-PascalCase_2021-03-19-15-52.json
+++ b/common/changes/@azure-tools/uri/deprecate-PascalCase_2021-03-19-15-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@azure-tools/uri",
+      "comment": "**Renamed** all function to be camelCase and deprecate PascalCase ones",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@azure-tools/uri",
+  "email": "tiguerin@microsoft.com"
+}

--- a/uri/src/data-acquisition.test.ts
+++ b/uri/src/data-acquisition.test.ts
@@ -1,20 +1,20 @@
-import { ExistsUri, ReadUri } from "./data-acquisition";
-import { CreateFileUri } from "./uri-manipulation";
+import { existsUri, readUri } from "./data-acquisition";
+import { createFileUri } from "./uri-manipulation";
 
 describe("Uri data acquisition", () => {
   it("ExistsUri", async () => {
-    expect(await ExistsUri("https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/README.md")).toBe(true);
-    expect(await ExistsUri("https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/READMEx.md")).toBe(
+    expect(await existsUri("https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/README.md")).toBe(true);
+    expect(await existsUri("https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/READMEx.md")).toBe(
       false,
     );
-    expect(await ExistsUri(CreateFileUri(__filename))).toEqual(true);
-    expect(await ExistsUri(CreateFileUri(__filename + "_"))).toEqual(false);
+    expect(await existsUri(createFileUri(__filename))).toEqual(true);
+    expect(await existsUri(createFileUri(__filename + "_"))).toEqual(false);
   });
 
   it("ReadUri", async () => {
     expect(
-      (await ReadUri("https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/README.md")).length > 0,
+      (await readUri("https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/README.md")).length > 0,
     ).toBeTruthy();
-    expect((await ReadUri(CreateFileUri(__filename))).length > 0).toBeTruthy();
+    expect((await readUri(createFileUri(__filename))).length > 0).toBeTruthy();
   });
 });

--- a/uri/src/data-acquisition.ts
+++ b/uri/src/data-acquisition.ts
@@ -1,5 +1,5 @@
 import * as getUri from "get-uri";
-import { ToRawDataUrl } from "./uri-manipulation";
+import { toRawDataUrl } from "./uri-manipulation";
 import { Readable } from "stream";
 
 function stripBom(text: string): string {
@@ -16,9 +16,10 @@ function getUriAsync(uri: string, options: { headers: { [key: string]: string } 
 
 /**
  * Loads a UTF8 string from given URI.
+ * @uri to load. Can be a remote url or a local file path(using file: protocol).
  */
-export async function ReadUri(uri: string, headers: { [key: string]: string } = {}): Promise<string> {
-  const actualUri = ToRawDataUrl(uri);
+export async function readUri(uri: string, headers: { [key: string]: string } = {}): Promise<string> {
+  const actualUri = toRawDataUrl(uri);
   const readable = await getUriAsync(actualUri, { headers: headers });
 
   const readAll = new Promise<Buffer>(function (resolve, reject) {
@@ -40,11 +41,21 @@ export async function ReadUri(uri: string, headers: { [key: string]: string } = 
   return stripBom(result.toString("utf8"));
 }
 
-export async function ExistsUri(uri: string): Promise<boolean> {
+export async function existsUri(uri: string): Promise<boolean> {
   try {
-    await ReadUri(uri);
+    await readUri(uri);
     return true;
   } catch (e) {
     return false;
   }
 }
+
+/**
+ * @deprecated use readUri instead
+ */
+export const ReadUri = readUri;
+
+/**
+ * @deprecated use existsUri instead
+ */
+export const ExistsUri = existsUri;

--- a/uri/src/index.ts
+++ b/uri/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./os-abstractions";
 export * from "./uri-manipulation";
+export * from "./data-acquisition";

--- a/uri/src/os-abstractions.test.ts
+++ b/uri/src/os-abstractions.test.ts
@@ -1,11 +1,11 @@
-import { EnumerateFiles } from "./os-abstractions";
-import { CreateFileUri, CreateFolderUri } from "./uri-manipulation";
+import { enumerateFiles } from "./os-abstractions";
+import { createFileUri, createFolderUri } from "./uri-manipulation";
 
 describe("Uri Os Abstractions", () => {
   it("EnumerateFiles local", async () => {
     let foundMyself = false;
-    for (const file of await EnumerateFiles(CreateFolderUri(__dirname))) {
-      if (file === CreateFileUri(__filename)) {
+    for (const file of await enumerateFiles(createFolderUri(__dirname))) {
+      if (file === createFileUri(__filename)) {
         foundMyself = true;
       }
     }
@@ -13,7 +13,7 @@ describe("Uri Os Abstractions", () => {
   });
 
   it("EnumerateFiles remote", async () => {
-    const files = await EnumerateFiles("https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/", [
+    const files = await enumerateFiles("https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/", [
       "README.md",
     ]);
     expect(files).not.toHaveLength(0);

--- a/uri/src/uri-manipulation.test.ts
+++ b/uri/src/uri-manipulation.test.ts
@@ -1,70 +1,70 @@
 import {
-  CreateFileUri,
-  CreateFolderUri,
-  ParentFolderUri,
-  ResolveUri,
+  createFileUri,
+  createFolderUri,
+  parentFolderUri,
+  resolveUri,
   simplifyUri,
-  ToRawDataUrl,
+  toRawDataUrl,
 } from "./uri-manipulation";
 
 describe("Uri Manipulation", () => {
   it("CreateFileUri", async () => {
-    expect(CreateFileUri("C:\\windows\\path\\file.txt")).toEqual("file:///C:/windows/path/file.txt");
-    expect(CreateFileUri("/linux/path/file.txt")).toEqual("file:///linux/path/file.txt");
-    expect(() => CreateFileUri("relpath\\file.txt")).toThrow();
-    expect(() => CreateFileUri("relpath/file.txt")).toThrow();
+    expect(createFileUri("C:\\windows\\path\\file.txt")).toEqual("file:///C:/windows/path/file.txt");
+    expect(createFileUri("/linux/path/file.txt")).toEqual("file:///linux/path/file.txt");
+    expect(() => createFileUri("relpath\\file.txt")).toThrow();
+    expect(() => createFileUri("relpath/file.txt")).toThrow();
   });
 
   it("CreateFolderUri", async () => {
-    expect(CreateFolderUri("C:\\windows\\path\\")).toEqual("file:///C:/windows/path/");
-    expect(CreateFolderUri("/linux/path/")).toEqual("file:///linux/path/");
-    expect(() => CreateFolderUri("relpath\\")).toThrow();
-    expect(() => CreateFolderUri("relpath/")).toThrow();
-    expect(() => CreateFolderUri("relpath")).toThrow();
-    expect(() => CreateFolderUri("relpath")).toThrow();
+    expect(createFolderUri("C:\\windows\\path\\")).toEqual("file:///C:/windows/path/");
+    expect(createFolderUri("/linux/path/")).toEqual("file:///linux/path/");
+    expect(() => createFolderUri("relpath\\")).toThrow();
+    expect(() => createFolderUri("relpath/")).toThrow();
+    expect(() => createFolderUri("relpath")).toThrow();
+    expect(() => createFolderUri("relpath")).toThrow();
   });
 
   it("ParentFolderUri", async () => {
-    expect(ParentFolderUri("https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/README.md")).toEqual(
+    expect(parentFolderUri("https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/README.md")).toEqual(
       "https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/",
     );
-    expect(ParentFolderUri("https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/")).toEqual(
+    expect(parentFolderUri("https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/")).toEqual(
       "https://raw.githubusercontent.com/Azure/azure-rest-api-specs/",
     );
-    expect(ParentFolderUri("https://raw.githubusercontent.com/Azure/azure-rest-api-specs/")).toEqual(
+    expect(parentFolderUri("https://raw.githubusercontent.com/Azure/azure-rest-api-specs/")).toEqual(
       "https://raw.githubusercontent.com/Azure/",
     );
-    expect(ParentFolderUri("https://raw.githubusercontent.com/Azure/")).toEqual("https://raw.githubusercontent.com/");
-    expect(ParentFolderUri("https://raw.githubusercontent.com/")).toEqual("https://");
-    expect(ParentFolderUri("https://")).toEqual(null);
+    expect(parentFolderUri("https://raw.githubusercontent.com/Azure/")).toEqual("https://raw.githubusercontent.com/");
+    expect(parentFolderUri("https://raw.githubusercontent.com/")).toEqual("https://");
+    expect(parentFolderUri("https://")).toEqual(null);
   });
 
   it("ResolveUri", async () => {
-    expect(ResolveUri("https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/", "README.md")).toEqual(
+    expect(resolveUri("https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/", "README.md")).toEqual(
       "https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/README.md",
     );
-    expect(ResolveUri("https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/", "../README.md")).toEqual(
+    expect(resolveUri("https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/", "../README.md")).toEqual(
       "https://raw.githubusercontent.com/Azure/azure-rest-api-specs/README.md",
     );
-    expect(ResolveUri("https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master", "README.md")).toEqual(
+    expect(resolveUri("https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master", "README.md")).toEqual(
       "https://raw.githubusercontent.com/Azure/azure-rest-api-specs/README.md",
     );
     expect(
-      ResolveUri("https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master", "file:///README.md"),
+      resolveUri("https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master", "file:///README.md"),
     ).toEqual("file:///README.md");
-    expect(ResolveUri("https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master", "/README.md")).toEqual(
+    expect(resolveUri("https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master", "/README.md")).toEqual(
       "file:///README.md",
     );
-    expect(ResolveUri("https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master", "C:\\README.md")).toEqual(
+    expect(resolveUri("https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master", "C:\\README.md")).toEqual(
       "file:///C:/README.md",
     );
     // multi-slash collapsing
     expect(
-      ResolveUri("https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/", "folder///file.md"),
+      resolveUri("https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/", "folder///file.md"),
     ).toEqual("https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/folder/file.md");
     // token forwarding
     expect(
-      ResolveUri(
+      resolveUri(
         "https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/file1.json?token=asd%3Dnot_really_a_token123%3D",
         "./file2.json",
       ),
@@ -72,37 +72,37 @@ describe("Uri Manipulation", () => {
       "https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/file2.json?token=asd%3Dnot_really_a_token123%3D",
     );
     expect(
-      ResolveUri(
+      resolveUri(
         "https://myprivatepage.com/file1.json?token=asd%3Dnot_really_a_token123%3D",
         "https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/file2.json",
       ),
     ).toEqual("https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/file2.json");
     expect(
-      ResolveUri(
+      resolveUri(
         "https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/file1.json?token=asd%3Dnot_really_a_token123%3D",
         "https://evil.com/file2.json",
       ),
     ).toEqual("https://evil.com/file2.json");
-    expect(ResolveUri("https://somewhere.com/file1.json?token=asd%3Dnot_really_a_token123%3D", "./file2.json")).toEqual(
+    expect(resolveUri("https://somewhere.com/file1.json?token=asd%3Dnot_really_a_token123%3D", "./file2.json")).toEqual(
       "https://somewhere.com/file2.json",
     );
   });
 
   it("ToRawDataUrl", async () => {
     // GitHub blob
-    expect(ToRawDataUrl("https://github.com/Microsoft/vscode/blob/master/.gitignore")).toEqual(
+    expect(toRawDataUrl("https://github.com/Microsoft/vscode/blob/master/.gitignore")).toEqual(
       "https://raw.githubusercontent.com/Microsoft/vscode/master/.gitignore",
     );
-    expect(ToRawDataUrl("https://github.com/Microsoft/TypeScript/blob/master/README.md")).toEqual(
+    expect(toRawDataUrl("https://github.com/Microsoft/TypeScript/blob/master/README.md")).toEqual(
       "https://raw.githubusercontent.com/Microsoft/TypeScript/master/README.md",
     );
     expect(
-      ToRawDataUrl("https://github.com/Microsoft/TypeScript/blob/master/tests/cases/compiler/APISample_watcher.ts"),
+      toRawDataUrl("https://github.com/Microsoft/TypeScript/blob/master/tests/cases/compiler/APISample_watcher.ts"),
     ).toEqual(
       "https://raw.githubusercontent.com/Microsoft/TypeScript/master/tests/cases/compiler/APISample_watcher.ts",
     );
     expect(
-      ToRawDataUrl(
+      toRawDataUrl(
         "https://github.com/Azure/azure-rest-api-specs/blob/master/arm-web/2015-08-01/AppServiceCertificateOrders.json",
       ),
     ).toEqual(
@@ -111,23 +111,23 @@ describe("Uri Manipulation", () => {
 
     // unknown / already raw
     expect(
-      ToRawDataUrl(
+      toRawDataUrl(
         "https://raw.githubusercontent.com/Microsoft/TypeScript/master/tests/cases/compiler/APISample_watcher.ts",
       ),
     ).toEqual(
       "https://raw.githubusercontent.com/Microsoft/TypeScript/master/tests/cases/compiler/APISample_watcher.ts",
     );
     expect(
-      ToRawDataUrl(
+      toRawDataUrl(
         "https://assets.onestore.ms/cdnfiles/external/uhf/long/9a49a7e9d8e881327e81b9eb43dabc01de70a9bb/images/microsoft-gray.png",
       ),
     ).toEqual(
       "https://assets.onestore.ms/cdnfiles/external/uhf/long/9a49a7e9d8e881327e81b9eb43dabc01de70a9bb/images/microsoft-gray.png",
     );
-    expect(ToRawDataUrl("README.md")).toEqual("README.md");
-    expect(ToRawDataUrl("compiler/APISample_watcher.ts")).toEqual("compiler/APISample_watcher.ts");
-    expect(ToRawDataUrl("compiler\\APISample_watcher.ts")).toEqual("compiler/APISample_watcher.ts");
-    expect(ToRawDataUrl("C:\\arm-web\\2015-08-01\\AppServiceCertificateOrders.json")).toEqual(
+    expect(toRawDataUrl("README.md")).toEqual("README.md");
+    expect(toRawDataUrl("compiler/APISample_watcher.ts")).toEqual("compiler/APISample_watcher.ts");
+    expect(toRawDataUrl("compiler\\APISample_watcher.ts")).toEqual("compiler/APISample_watcher.ts");
+    expect(toRawDataUrl("C:\\arm-web\\2015-08-01\\AppServiceCertificateOrders.json")).toEqual(
       "c:/arm-web/2015-08-01/AppServiceCertificateOrders.json",
     );
   });

--- a/uri/src/uri-manipulation.ts
+++ b/uri/src/uri-manipulation.ts
@@ -18,7 +18,7 @@ export function simplifyUri(uri: string): string {
   }
 }
 
-export function IsUri(uri: string): boolean {
+export function isUri(uri: string): boolean {
   return /^([a-z0-9+.-]+):(?:\/\/(?:((?:[a-z0-9-._~!$&'()*+,;=:]|%[0-9A-F]{2})*)@)?((?:[a-z0-9-._~!$&'()*+,;=]|%[0-9A-F]{2})*)(?::(\d*))?(\/(?:[a-z0-9-._~!$&'()*+,;=:@/]|%[0-9A-F]{2})*)?|(\/?(?:[a-z0-9-._~!$&'()*+,;=:@]|%[0-9A-F]{2})+(?:[a-z0-9-._~!$&'()*+,;=:@/]|%[0-9A-F]{2})*)?)(?:\?((?:[a-z0-9-._~!$&'()*+,;=:/?@]|%[0-9A-F]{2})*))?(?:#((?:[a-z0-9-._~!$&'()*+,;=:/?@]|%[0-9A-F]{2})*))?$/i.test(
     uri,
   );
@@ -48,7 +48,7 @@ function isUriAbsolute(url: string): boolean {
  * - "C:\swagger\storage.yaml" -> "file:///C:/swagger/storage.yaml"
  * - "/input/swagger.yaml" -> "file:///input/swagger.yaml"
  */
-export function CreateFileOrFolderUri(absolutePath: string): string {
+export function createFileOrFolderUri(absolutePath: string): string {
   if (!isAbsolute(absolutePath)) {
     throw new Error(`Can only create file URIs from absolute paths. Got '${absolutePath}'`);
   }
@@ -60,31 +60,31 @@ export function CreateFileOrFolderUri(absolutePath: string): string {
   return result;
 }
 
-export function EnsureIsFileUri(uri: string): string {
+export function ensureIfFileUri(uri: string): string {
   return uri.replace(/\/$/g, "");
 }
 
-export function EnsureIsFolderUri(uri: string): string {
-  return EnsureIsFileUri(uri) + "/";
+export function ensureIsFolderUri(uri: string): string {
+  return ensureIfFileUri(uri) + "/";
 }
-export function CreateFileUri(absolutePath: string): string {
-  return EnsureIsFileUri(CreateFileOrFolderUri(absolutePath));
+export function createFileUri(absolutePath: string): string {
+  return ensureIfFileUri(createFileOrFolderUri(absolutePath));
 }
-export function CreateFolderUri(absolutePath: string): string {
-  return EnsureIsFolderUri(CreateFileOrFolderUri(absolutePath));
+export function createFolderUri(absolutePath: string): string {
+  return ensureIsFolderUri(createFileOrFolderUri(absolutePath));
 }
 
-export function GetFilename(uri: string): string {
+export function getFilename(uri: string): string {
   return uri.split("/").reverse()[0].split("\\").reverse()[0];
 }
 
-export function GetFilenameWithoutExtension(uri: string): string {
-  const lastPart = GetFilename(uri);
+export function getFilenameWithoutExtension(uri: string): string {
+  const lastPart = getFilename(uri);
   const ext = lastPart.indexOf(".") === -1 ? "" : lastPart.split(".").reverse()[0];
   return lastPart.substr(0, lastPart.length - ext.length - 1);
 }
 
-export function ToRawDataUrl(uri: string): string {
+export function toRawDataUrl(uri: string): string {
   uri = simplifyUri(uri);
 
   // special URI handlers (the 'if's shouldn't be necessary but provide some additional isolation in case there is anything wrong with one of the regexes)
@@ -116,12 +116,12 @@ export function ToRawDataUrl(uri: string): string {
  * @param pathOrUri Relative/absolute path/URI
  * @returns Absolute URI
  */
-export function ResolveUri(baseUri: string, pathOrUri: string): string {
+export function resolveUri(baseUri: string, pathOrUri: string): string {
   if (pathOrUri.startsWith("~/")) {
     pathOrUri = pathOrUri.replace(/^~/, homedir());
   }
   if (isAbsolute(pathOrUri)) {
-    return CreateFileOrFolderUri(pathOrUri);
+    return createFileOrFolderUri(pathOrUri);
   }
 
   // known here: `pathOrUri` is eiher URI (relative or absolute) or relative path - which we can normalize to a relative URI
@@ -158,7 +158,7 @@ export function ResolveUri(baseUri: string, pathOrUri: string): string {
   }
 }
 
-export function ParentFolderUri(uri: string): string | null {
+export function parentFolderUri(uri: string): string | null {
   // root?
   if (uri.endsWith("//")) {
     return null;
@@ -172,6 +172,57 @@ export function ParentFolderUri(uri: string): string | null {
   return uri.slice(0, uri.length - compLen);
 }
 
-export function MakeRelativeUri(baseUri: string, absoluteUri: string): string {
+export function makeRelativeUri(baseUri: string, absoluteUri: string): string {
   return new URI(absoluteUri).relativeTo(baseUri).toString();
 }
+//------------------------------------------
+// Legacy names, will be removed in next major version
+//------------------------------------------
+/**
+ * @deprecated use isUri instead.
+ */
+export const IsUri = isUri;
+/**
+ * @deprecated use createFileOrFolderUri instead.
+ */
+export const CreateFileOrFolderUri = createFileOrFolderUri;
+/**
+ * @deprecated use ensureIfFileUri instead.
+ */
+export const EnsureIfFileUri = ensureIfFileUri;
+/**
+ * @deprecated use ensureIsFolderUri instead.
+ */
+export const EnsureIsFolderUri = ensureIsFolderUri;
+/**
+ * @deprecated use createFileUri instead.
+ */
+export const CreateFileUri = createFileUri;
+/**
+ * @deprecated use createFolderUri instead.
+ */
+export const CreateFolderUri = createFolderUri;
+/**
+ * @deprecated use toRawDataUrl instead.
+ */
+export const ToRawDataUrl = toRawDataUrl;
+/**
+ * @deprecated use getFilename instead.
+ */
+export const GetFilename = getFilename;
+/**
+ * @deprecated use getFilenameWithoutExtension instead.
+ */
+export const GetFilenameWithoutExtension = getFilenameWithoutExtension;
+/**
+ * @deprecated use resolveUri instead.
+ */
+export const ResolveUri = resolveUri;
+/**
+ * @deprecated use parentFolderUri instead.
+ */
+export const ParentFolderUri = parentFolderUri;
+/**
+ * @deprecated use makeRelativeUri instead.
+ */
+export const MakeRelativeUri = makeRelativeUri;


### PR DESCRIPTION
Rename to be consistent with `js/ts` naming. Added alias marked as deprecated for the old names.