### PR TITLE
[CODEOWNERS] Remove automation section

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,1 @@
-################
-# Automation
-################
 
-# Git Hub bot rules
-/.github/CODEOWNERS  @jsquire @ronniegeraghty
-/.github/fabricbot.json  @jsquire @ronniegeraghty


### PR DESCRIPTION
# Summary

The focus of these changes is to remove the automation section, as CODEOWNERS changes no longer require manual syncing.